### PR TITLE
New video metadata parsing case

### DIFF
--- a/src/app/components/VideoPlayer/index.js
+++ b/src/app/components/VideoPlayer/index.js
@@ -373,10 +373,19 @@ function getMetadata(videoElOrId, callback) {
   }
 
   if (isElement(videoElOrId)) {
-    done(null, {
-      posterURL: videoElOrId.poster,
-      sources: formatSources($$('source', videoElOrId))
-    });
+    if (videoElOrId.className.indexOf('jw-') > -1) {
+      // JWPLayer <video> with src attribute and nearby element with poster as a background-image
+      done(null, {
+        posterURL: (videoElOrId.parentElement.nextElementSibling.style.backgroundImage.match(CSS_URL) || [, ''])[1],
+        sources: formatSources([videoElOrId])
+      });
+    } else {
+      // <video> with poster attribute and <source> children
+      done(null, {
+        posterURL: videoElOrId.poster,
+        sources: formatSources($$('source', videoElOrId))
+      });
+    }
   } else if ('WCMS' in window) {
     // Phase 2
     // * Poster & sources are nested inside global `WCMS` object


### PR DESCRIPTION
…where `videoElOrId` is a native `<video>`, but part of the new JWPlayer (not a Phase 1 Mobile native video).