### PR TITLE
VideoPlayer controls & inline playback is now dependent on screen dimensions.

### DIFF
--- a/src/app/components/MasterGallery/index.js
+++ b/src/app/components/MasterGallery/index.js
@@ -4,8 +4,8 @@ const screenfull = require('screenfull');
 const url2cmid = require('util-url2cmid');
 
 // Ours
-const {enqueue, invalidateClient} = require('../../scheduler');
-const {$, $$, prepend} = require('../../utils/dom');
+const { enqueue, invalidateClient } = require('../../scheduler');
+const { $, $$, prepend } = require('../../utils/dom');
 const Caption = require('../Caption');
 const Gallery = require('../Gallery');
 const Picture = require('../Picture');
@@ -26,7 +26,7 @@ function MasterGallery() {
     return html`<div class="MasterGallery is-empty"></div>`;
   }
 
-  const galleryEl = Gallery({images});
+  const galleryEl = Gallery({ images });
 
   galleryEl.classList.remove('u-full');
 
@@ -41,13 +41,7 @@ function MasterGallery() {
   }
 
   window.addEventListener('click', event => {
-    if (
-      (event.button && event.button !== 0) ||
-      event.ctrlKey ||
-      event.metaKey ||
-      event.altKey ||
-      event.shiftKey
-    ) {
+    if ((event.button && event.button !== 0) || event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) {
       return;
     }
 
@@ -56,12 +50,8 @@ function MasterGallery() {
         return;
       }
 
-      if (
-        (node.localName !== 'a') ||
-        (node.href === undefined) ||
-        (window.location.host !== node.host)
-      ) {
-         return traverse(node.parentNode);
+      if (node.localName !== 'a' || node.href === undefined || window.location.host !== node.host) {
+        return traverse(node.parentNode);
       }
 
       return node;
@@ -117,11 +107,11 @@ function MasterGallery() {
       role="dialog"
       aria-label="Gallery of all photos in this story"
       tabindex="-1"
-      onclick=${function (event) {
+      onclick=${function(event) {
         if (this === event.target) {
           close();
         }
-    }}>
+      }}>
       <div class="MasterGallery-container u-richtext-invert">
         ${galleryEl}
       </div>
@@ -150,7 +140,10 @@ function open(el) {
 
 function close() {
   document.documentElement.classList.remove('is-master-gallery-open');
-  externalActiveElement.focus();
+
+  if (externalActiveElement) {
+    externalActiveElement.focus();
+  }
 
   if (screenfull.isFullscreen) {
     screenfull.exit();
@@ -188,7 +181,7 @@ function register(el) {
   }
 
   registeredImageIds[id] = true;
-  
+
   images.push({
     id,
     pictureEl: Picture({

--- a/src/app/components/MasterGallery/index.scss
+++ b/src/app/components/MasterGallery/index.scss
@@ -2,20 +2,6 @@
 
 html.is-master-gallery-open {
   overflow: hidden;
-
-  #abcHeader {
-    display: none;
-  }
-
-  .Nav {
-    @media #{$mq-not-lg} and #{$mq-gt-4-3} {
-      display: none;
-    }
-  }
-
-  .Nav-bar {
-    transform: none;
-  }
 }
 
 .MasterGallery {
@@ -23,21 +9,17 @@ html.is-master-gallery-open {
   flex-direction: column;
   justify-content: center;
   position: fixed;
-  z-index: 2;
+  z-index: 3;
   top: 0;
   left: 0;
   margin-top: 0;
   margin-bottom: 0;
-  padding-top: $size-bar;
+  padding-top: 0;
   padding-right: 0;
   padding-left: 0;
   width: 100%;
   height: 100%;
   background-color: $color-black-transparent-93;
-
-  @media #{$mq-not-lg} and #{$mq-gt-4-3} {
-    padding-top: 0;
-  }
 
   html.is-master-gallery-open & {
     display: flex;
@@ -80,7 +62,7 @@ html.is-master-gallery-open {
 
       .Caption-attribution {
         display: block;
-        font-size: .8125rem !important;
+        font-size: 0.8125rem !important;
       }
     }
   }

--- a/src/app/components/Nav/index.scss
+++ b/src/app/components/Nav/index.scss
@@ -1,10 +1,13 @@
 @import '../../../constants';
 
 .Nav {
-  z-index: 3;
-  position: relative;
   height: $size-bar;
-  background-color:$color-grey-brand;
+  background-color: $color-grey-brand;
+
+  &.is-above {
+    position: relative;
+    z-index: 3;
+  }
 }
 
 .Nav-bar {
@@ -14,7 +17,7 @@
   width: 100%;
   height: $size-bar;
   background-color: $color-grey-brand;
-  transition: transform .25s cubic-bezier(0, 0, .32, 1);
+  transition: transform 0.25s cubic-bezier(0, 0, 0.32, 1);
   will-change: transform;
 
   .is-above & {

--- a/src/app/components/VideoEmbed/index.scss
+++ b/src/app/components/VideoEmbed/index.scss
@@ -3,7 +3,7 @@
 .VideoEmbed {
   &.u-full {
     min-height: 56.25vw;
-    min-height: calc(var(--root-width) * .5625);
+    min-height: calc(var(--root-width, 100vw) * 0.5625);
 
     &.is-cover {
       height: 100vh;
@@ -21,19 +21,17 @@
       width: 100%;
     }
 
-    .Main > [class*="u-pull"] > & {
+    .Main > [class*='u-pull'] > & {
       margin-left: -$layout-fluid-padding;
       margin-right: -$layout-fluid-padding;
     }
   }
 
   @media #{$mq-md} {
-    .Main > &:not([class*="u-pull-"]) {
+    .Main > &:not([class*='u-pull-']) {
       padding-left: 0;
       padding-right: 0;
       width: 100%;
     }
   }
 }
-
-

--- a/src/app/components/VideoPlayer/index.js
+++ b/src/app/components/VideoPlayer/index.js
@@ -6,15 +6,15 @@ const url2cmid = require('util-url2cmid');
 const xhr = require('xhr');
 
 // Ours
-const {CSS_URL, IS_IOS, MQ, MS_VERSION, SMALLEST_IMAGE} = require('../../../constants');
-const {getMeta} = require('../../meta');
-const {enqueue, invalidateClient, subscribe} = require('../../scheduler');
-const {$, $$, append, isElement, setText, toggleAttribute, toggleBooleanAttributes} = require('../../utils/dom');
-const {proximityCheck, twoDigits, whenKeyIn} = require('../../utils/misc');
+const { CSS_URL, IS_IOS, MQ, MS_VERSION, SMALLEST_IMAGE } = require('../../../constants');
+const { getMeta } = require('../../meta');
+const { enqueue, invalidateClient, subscribe } = require('../../scheduler');
+const { $, $$, append, isElement, setText, toggleAttribute, toggleBooleanAttributes } = require('../../utils/dom');
+const { proximityCheck, twoDigits, whenKeyIn } = require('../../utils/misc');
 require('./index.scss');
 
 const NEWLINES_PATTERN = /[\n\r]/g;
-const AMBIENT_PLAYABLE_RANGE = .5;
+const AMBIENT_PLAYABLE_RANGE = 0.5;
 const FUZZY_INCREMENT_FPS = 30;
 const FUZZY_INCREMENT_INTERVAL = 1000 / FUZZY_INCREMENT_FPS;
 const STEP_SECONDS = 5;
@@ -23,21 +23,10 @@ const DEFAULT_RATIO = '16x9';
 const players = [];
 
 function hasAudio(el) {
-  return el.mozHasAudio ||
-    !!el.webkitAudioDecodedByteCount ||
-    !!(el.audioTracks && el.audioTracks.length);
+  return el.mozHasAudio || !!el.webkitAudioDecodedByteCount || !!(el.audioTracks && el.audioTracks.length);
 }
 
-function VideoPlayer({
-  ratios = {},
-  posterURL,
-  sources = [],
-  isAmbient,
-  isAlwaysHQ,
-  isLoop,
-  isMuted,
-  scrollplayPct
-}) {
+function VideoPlayer({ ratios = {}, posterURL, sources = [], isAmbient, isAlwaysHQ, isLoop, isMuted, scrollplayPct }) {
   ratios = {
     sm: ratios.sm || DEFAULT_RATIO,
     md: ratios.md || DEFAULT_RATIO,
@@ -65,7 +54,7 @@ function VideoPlayer({
     'webkit-playsinline': true
   });
 
-   // Firefox doesn't respect the muted attribute initially.
+  // Firefox doesn't respect the muted attribute initially.
   if (isMuted && !videoEl.muted) {
     videoEl.muted = true;
   }
@@ -97,7 +86,7 @@ function VideoPlayer({
     if (muteEl) {
       muteEl.setAttribute('aria-label', videoEl.muted ? 'Unmute' : 'Mute');
     }
-  };
+  }
 
   let fuzzyCurrentTime = 0;
   let fuzzyTimeout;
@@ -113,8 +102,56 @@ function VideoPlayer({
     fuzzyTimeout = setTimeout(nextFuzzyIncrement, FUZZY_INCREMENT_INTERVAL);
   }
 
+  videoEl.addEventListener('timeupdate', () => {
+    fuzzyCurrentTime = videoEl.currentTime;
+  });
+
+  videoEl.addEventListener('playing', () => {
+    if (isScrubbing) {
+      return;
+    }
+
+    // Stop all other non-ambient videos
+    if (!player.isAmbient) {
+      players.forEach(_player => {
+        if (_player !== player && !_player.isAmbient) {
+          _player.pause();
+        }
+      });
+    }
+
+    // Reset video if it had ended
+    if (videoEl.hasAttribute('ended')) {
+      videoEl.removeAttribute('ended');
+      videoEl.currentTime = 0;
+    }
+
+    // Update attributes
+    videoEl.removeAttribute('paused');
+
+    if (playbackEl) {
+      playbackEl.setAttribute('aria-label', 'Pause');
+    }
+
+    // Incrememnt fuzzy time
+    nextFuzzyIncrement();
+  });
+
+  videoEl.addEventListener('pause', () => {
+    if (isScrubbing) {
+      return;
+    }
+
+    videoEl.setAttribute('paused', '');
+
+    if (playbackEl) {
+      playbackEl.setAttribute('aria-label', 'Play');
+    }
+
+    clearTimeout(fuzzyTimeout);
+  });
+
   videoEl.addEventListener('play', nextFuzzyIncrement);
-  videoEl.addEventListener('playing', nextFuzzyIncrement);
   videoEl.addEventListener('stalled', clearTimeout(fuzzyTimeout));
   videoEl.addEventListener('waiting', clearTimeout(fuzzyTimeout));
 
@@ -140,6 +177,7 @@ function VideoPlayer({
   });
 
   const player = {
+    hasNativeUI: false,
     isAmbient,
     isScrollplay,
     scrollplayPct,
@@ -147,51 +185,24 @@ function VideoPlayer({
       // Fixed players should use their parent's rect, as they're always in the viewport
       const playerEl = videoEl.parentElement;
       const position = window.getComputedStyle(playerEl).position;
-      const el = (position === 'fixed' ? playerEl.parentElement : playerEl);
+      const el = position === 'fixed' ? playerEl.parentElement : playerEl;
 
       return el.getBoundingClientRect();
     },
+    getVideoEl: () => videoEl,
     play: () => {
       if (!videoEl.paused) {
         return;
       }
-      
-      // Stop all other non-ambient videos
-      if (!player.isAmbient) {
-        players.forEach(_player => {
-          if (_player !== player && !_player.isAmbient) {
-            _player.pause();
-          }
-        });
-      }
 
-      // Reset video if it had ended
-      if (videoEl.hasAttribute('ended')) {
-        videoEl.removeAttribute('ended');
-        videoEl.currentTime = 0;
-      }
-
-      // Play and update attributes
-      (videoEl.play() || {then: x => x()})
-      .then(() => {
-        videoEl.removeAttribute('paused');
-
-        if (playbackEl) {
-          playbackEl.setAttribute('aria-label', 'Pause');
-        }
-      });
+      videoEl.play();
     },
     pause: () => {
       if (videoEl.paused) {
         return;
       }
-      
-      videoEl.pause();
-      videoEl.setAttribute('paused', '');
 
-      if (playbackEl) {
-        playbackEl.setAttribute('aria-label', 'Play');
-      }
+      videoEl.pause();
     },
     togglePlayback: (event, wasScrollBased) => {
       if (!wasScrollBased && !player.isAmbient) {
@@ -242,7 +253,7 @@ function VideoPlayer({
 
     if (steppingKeysHeldDown.indexOf(event.keyCode) === steppingKeysHeldDown.length - 1) {
       const isSteppingForwards = event.keyCode === 38 || event.keyCode === 39;
-    
+
       jumpTo(videoEl.currentTime + STEP_SECONDS * (isSteppingForwards ? 1 : -1));
     }
   }
@@ -266,11 +277,11 @@ function VideoPlayer({
     if (!isScrubbing) {
       return;
     }
-    
+
     if (!isPassive) {
       event.preventDefault();
     }
-    
+
     const clientX = event.touches ? event.touches[0].clientX : event.clientX;
     const rect = progressEl.getBoundingClientRect();
 
@@ -281,11 +292,11 @@ function VideoPlayer({
     if (!isScrubbing) {
       return;
     }
-        
+
     if (wasPlayingBeforeScrubbing) {
       videoEl.play();
     }
-    
+
     isScrubbing = false;
   }
 
@@ -314,7 +325,7 @@ function VideoPlayer({
     ></progress>`;
     progressEl = html`<div class="VideoPlayer-progress">
       ${progressBarEl}
-    </div>`
+    </div>`;
     controlsEl = html`<div class="VideoPlayer-controls">
       ${playbackEl}
       ${muteEl}
@@ -325,13 +336,11 @@ function VideoPlayer({
     videoEl.addEventListener('timeupdate', () => {
       if (videoEl.readyState > 0) {
         const secondsRemaining = videoEl.duration - videoEl.currentTime;
-        const formattedNegativeTimeFromEnd = isNaN(secondsRemaining) ? '' : `${
-          secondsRemaining > 0 ? '-' : ''
-        }${
-          twoDigits(Math.floor(secondsRemaining / 60))
-        }:${
-          twoDigits(Math.round(secondsRemaining % 60))
-        }`;
+        const formattedNegativeTimeFromEnd = isNaN(secondsRemaining)
+          ? ''
+          : `${secondsRemaining > 0 ? '-' : ''}${twoDigits(Math.floor(secondsRemaining / 60))}:${twoDigits(
+              Math.round(secondsRemaining % 60)
+            )}`;
 
         setText(timeRemainingEl, formattedNegativeTimeFromEnd);
         player.currentFuzzyTime = videoEl.currentTime;
@@ -339,12 +348,14 @@ function VideoPlayer({
     });
 
     progressEl.addEventListener('mousedown', scrubStart);
-    progressEl.addEventListener('touchstart', scrubStart, {passive: true});
+    progressEl.addEventListener('touchstart', scrubStart, { passive: true });
     document.addEventListener('mousemove', scrub);
-    document.addEventListener('touchmove', scrub, {passive: true});
+    document.addEventListener('touchmove', scrub, { passive: true });
     document.addEventListener('mouseup', scrubEnd);
     document.addEventListener('touchend', scrubEnd);
     document.addEventListener('touchcancel', scrubEnd);
+
+    updateUI(player);
   }
 
   const videoPlayerEl = html`
@@ -358,7 +369,7 @@ function VideoPlayer({
   videoPlayerEl.api = player;
 
   return videoPlayerEl;
-};
+}
 
 function getMetadata(videoElOrId, callback) {
   let wasCalled;
@@ -381,8 +392,7 @@ function getMetadata(videoElOrId, callback) {
     // Phase 2
     // * Poster & sources are nested inside global `WCMS` object
 
-    Object.keys(WCMS.pluginCache.plugins.videoplayer)
-    .some(key => {
+    Object.keys(WCMS.pluginCache.plugins.videoplayer).some(key => {
       const config = WCMS.pluginCache.plugins.videoplayer[key][0].videos[0];
 
       if (config.url.indexOf(videoElOrId) > -1) {
@@ -402,31 +412,31 @@ function getMetadata(videoElOrId, callback) {
     const relatedMedia = getMeta().relatedMedia;
 
     $$('.inline-content.video[data-inline-video-data-index]')
-    .concat(relatedMedia ? [relatedMedia] : [])
-    .some(el => {
-      if ($(`[href*="/${videoElOrId}"]`, el)) {
-        const posterEl = $('img, .inline-video', el);
+      .concat(relatedMedia ? [relatedMedia] : [])
+      .some(el => {
+        if ($(`[href*="/${videoElOrId}"]`, el)) {
+          const posterEl = $('img, .inline-video', el);
 
-        done(null, {
-          posterURL: posterEl ? (posterEl.style.backgroundImage.match(CSS_URL) || [, posterEl.src])[1] : null,
-          sources: formatSources(window.inlineVideoData[el.getAttribute('data-inline-video-data-index')])
-        });
+          done(null, {
+            posterURL: posterEl ? (posterEl.style.backgroundImage.match(CSS_URL) || [, posterEl.src])[1] : null,
+            sources: formatSources(window.inlineVideoData[el.getAttribute('data-inline-video-data-index')])
+          });
 
-        return true;
-      }
-    });
+          return true;
+        }
+      });
   } else {
     // Phase 1 (Mobile):
     // * Doesn't embed video; only teases to it.
     // * Must fetch video detail page...
     // * ...then parse posterURL and sources, based on the page template
-    
-    xhr({url: `/news/${videoElOrId}`}, (err, response, body) => {
+
+    xhr({ url: `/news/${videoElOrId}` }, (err, response, body) => {
       if (err || response.statusCode !== 200) {
         return done(err || new Error(response.statusCode));
       }
 
-      const doc = (new DOMParser()).parseFromString(body, 'text/html');
+      const doc = new DOMParser().parseFromString(body, 'text/html');
 
       if (body.indexOf('WCMS.pluginCache') > -1) {
         // Phase 2
@@ -434,11 +444,13 @@ function getMetadata(videoElOrId, callback) {
         // * Sources can be parsed from JS that would nest them under the global `WCMS` object
 
         done(null, {
-          posterURL: doc.querySelector('.view-inlineMediaPlayer img')
-            .getAttribute('src').replace('-thumbnail', '-large'),
-          sources: formatSources(JSON.parse(body
-            .replace(NEWLINES_PATTERN, '')
-            .match(/"sources":(\[.*\]),"addDownload"/)[1]))
+          posterURL: doc
+            .querySelector('.view-inlineMediaPlayer img')
+            .getAttribute('src')
+            .replace('-thumbnail', '-large'),
+          sources: formatSources(
+            JSON.parse(body.replace(NEWLINES_PATTERN, '').match(/"sources":(\[.*\]),"addDownload"/)[1])
+          )
         });
       } else if (body.indexOf('inlineVideoData') > -1) {
         // Phase 1 (Standard)
@@ -447,10 +459,14 @@ function getMetadata(videoElOrId, callback) {
 
         done(null, {
           posterURL: doc.querySelector('.inline-video img').getAttribute('src'),
-          sources: formatSources(JSON.parse(body
-            .replace(NEWLINES_PATTERN, '')
-            .match(/inlineVideoData\.push\((\[.*\])\)/)[1]
-            .replace(/'/g, '"')))
+          sources: formatSources(
+            JSON.parse(
+              body
+                .replace(NEWLINES_PATTERN, '')
+                .match(/inlineVideoData\.push\((\[.*\])\)/)[1]
+                .replace(/'/g, '"')
+            )
+          )
         });
       } else {
         // Phase 1 (Mobile)
@@ -466,9 +482,7 @@ function getMetadata(videoElOrId, callback) {
 }
 
 function formatSources(sources, sortProp = 'bitrate') {
-  return sources
-  .sort((a, b) => +b[sortProp] - +a[sortProp])
-  .map(source => ({
+  return sources.sort((a, b) => +b[sortProp] - +a[sortProp]).map(source => ({
     src: source.src || source.url,
     type: source.type || source.contentType
   }));
@@ -481,9 +495,9 @@ subscribe(function _checkIfVideoPlayersNeedToBeToggled(client) {
     }
 
     const rect = player.getRect();
-    const isInPlayableRange = player.isAmbient ?
-      proximityCheck(rect, client, AMBIENT_PLAYABLE_RANGE) :
-      proximityCheck(rect, client, (player.scrollplayPct || 0) / -100);
+    const isInPlayableRange = player.isAmbient
+      ? proximityCheck(rect, client, AMBIENT_PLAYABLE_RANGE)
+      : proximityCheck(rect, client, (player.scrollplayPct || 0) / -100);
 
     if (
       (typeof player.isInPlayableRange === 'undefined' && isInPlayableRange) ||
@@ -491,10 +505,51 @@ subscribe(function _checkIfVideoPlayersNeedToBeToggled(client) {
     ) {
       enqueue(function _toggleVideoPlay() {
         player.togglePlayback(null, true);
-      })
+      });
     }
 
     player.isInPlayableRange = isInPlayableRange;
+  });
+});
+
+const mql = window.matchMedia('(max-height: 30rem)');
+let mqlDidMatch = mql.matches;
+
+function updateUI(player) {
+  const shouldBeNative = mql.matches;
+
+  player.hasNativeUI = shouldBeNative;
+
+  toggleBooleanAttributes(player.getVideoEl(), {
+    controls: shouldBeNative,
+    playsinline: !shouldBeNative,
+    'webkit-playsinline': !shouldBeNative
+  });
+}
+
+subscribe(function _checkIfVideoPlayersNeedToUpdateUIBasedOnMedia() {
+  if (mqlDidMatch === mql.matches) {
+    return;
+  }
+
+  mqlDidMatch = mql.matches;
+
+  players.forEach(player => {
+    if (player.isAmbient) {
+      return;
+    }
+
+    const wasPlaying = Boolean(player.paused);
+
+    enqueue(() => {
+      updateUI(player, mql.matches);
+
+      enqueue(() => {
+        if (wasPlaying && player.getVideoEl().scrollIntoView) {
+          player.getVideoEl().scrollIntoView(true);
+        }
+      });
+    });
   });
 });
 

--- a/src/app/components/VideoPlayer/index.scss
+++ b/src/app/components/VideoPlayer/index.scss
@@ -28,12 +28,32 @@
     vertical-align: top;
     object-fit: cover;
 
-    &::-webkit-media-controls-play-button,
-		&::-webkit-media-controls-start-playback-button {
-			opacity: 0;
-			width: .3125rem;
-			pointer-events: none;
-		}
+    &:-webkit-full-screen {
+      background-image: none !important;
+      object-fit: contain;
+    }
+
+    &:-moz-full-screen {
+      background-image: none !important;
+      object-fit: contain;
+    }
+
+    &:-ms-full-screen {
+      background-image: none !important;
+      object-fit: contain;
+    }
+
+    &:fullscreen {
+      background-image: none !important;
+      object-fit: contain;
+    }
+
+    &:not([controls])::-webkit-media-controls-play-button,
+    &:not([controls])::-webkit-media-controls-start-playback-button {
+      opacity: 0;
+      width: 0.3125rem;
+      pointer-events: none;
+    }
   }
 }
 
@@ -45,12 +65,16 @@
   left: 0;
   width: 100%;
   max-width: 100vw;
-  max-width: var(--root-width);
+  max-width: var(--root-width, 100vw);
   height: 100%;
+
+  [controls] + & {
+    display: none;
+  }
 
   & > :not(.VideoPlayer-playback) {
     opacity: 0;
-    transition: opacity .5s .5s;
+    transition: opacity 0.5s 0.5s;
   }
 
   & > button {
@@ -62,7 +86,7 @@
 
   &:hover > * {
     opacity: 1;
-    transition: opacity .25s;
+    transition: opacity 0.25s;
   }
 
   & > *:focus {
@@ -73,7 +97,7 @@
   [paused] + & > :not(:focus):not(.VideoPlayer-playback) {
     opacity: 0;
     pointer-events: none;
-    transition: opacity .25s;
+    transition: opacity 0.25s;
   }
 }
 
@@ -87,7 +111,7 @@
   -webkit-tap-highlight-color: $color-black-transparent;
 
   &::before {
-    content: "";
+    content: '';
     position: absolute;
     top: 50%;
     left: 50%;
@@ -100,7 +124,7 @@
     background-position: center;
     background-repeat: no-repeat;
     background-size: 100%;
-    transition: opacity .25s, transform .25s;
+    transition: opacity 0.25s, transform 0.25s;
     will-change: opacity, transform;
 
     @media #{$mq-md} {
@@ -171,9 +195,9 @@
   flex: 1 1 auto;
   z-index: 1;
   margin-left: 1.25rem;
-  margin-bottom: .625rem;
-  padding: .625rem 0;
-  line-height: .5rem;
+  margin-bottom: 0.625rem;
+  padding: 0.625rem 0;
+  line-height: 0.5rem;
   cursor: pointer;
   -webkit-tap-highlight-color: $color-black-transparent;
 }
@@ -184,39 +208,39 @@
   appearance: none;
   margin: 0;
   border: none;
-  padding: .125rem;
+  padding: 0.125rem;
   width: 100%;
-  height: .75rem;
+  height: 0.75rem;
   background-color: $color-black-transparent-60;
   color: $color-white-transparent-60;
 
   &::-webkit-progress-bar {
-		background: none;
-	}
+    background: none;
+  }
 
-	&::-webkit-progress-value {
-		background: $color-white-transparent-60;
-	}
+  &::-webkit-progress-value {
+    background: $color-white-transparent-60;
+  }
 
   &::-moz-progress-bar {
-		background: $color-white-transparent-60;
-	}
+    background: $color-white-transparent-60;
+  }
 
   &::-ms-fill {
-		background: $color-white-transparent-60;
-	}
+    background: $color-white-transparent-60;
+  }
 }
 
 .VideoPlayer-timeRemaining {
   margin-left: $size-control-margin;
-  padding: .25rem;
+  padding: 0.25rem;
   min-width: 3.75rem;
   height: 2rem;
   background-color: $color-black-transparent-60;
   color: $color-white;
   font-family: $font-sans;
-  font-size: .875rem;
+  font-size: 0.875rem;
   line-height: 1.5rem;
   text-align: center;
-  letter-spacing: .0375rem;
+  letter-spacing: 0.0375rem;
 }

--- a/src/app/components/utilities/full.scss
+++ b/src/app/components/utilities/full.scss
@@ -1,16 +1,15 @@
 @import '../../../constants';
 
 .u-layout > .u-full,
-[class*="u-richtext"] > .u-full {
+[class*='u-richtext'] > .u-full {
   margin-top: 2rem;
   margin-bottom: 2rem;
   margin-left: calc(-50vw + 50%) !important;
-  margin-left: calc((var(--root-width) / -2) + 50%) !important;
+  margin-left: calc((var(--root-width, 100vw) / -2) + 50%) !important;
   padding-left: 0;
   padding-right: 0;
   width: 100vw;
-  width: var(--root-width);
-  
+  width: var(--root-width, 100vw);
 
   @media #{$mq-lg} {
     margin-top: 3rem;
@@ -26,23 +25,22 @@
   html.fixed & {
     @media (max-width: $p1s-fixed-width) {
       min-width: $p1s-fixed-width;
-      margin-left: -.625rem  !important;
+      margin-left: -.625rem !important;
     }
 
     @media #{$mq-not-lg} {
-      margin-left: 0  !important;
+      margin-left: 0 !important;
     }
   }
 }
 
 .u-layout > .u-full:not(.Gallery) + .u-full:not(.Gallery),
 .u-layout > .u-full:not(.Gallery) + a[name] + .u-full:not(.Gallery),
-[class*="u-richtext"] > .u-full:not(.Gallery) + .u-full:not(.Gallery),
-[class*="u-richtext"] > .u-full:not(.Gallery) + a[name] + .u-full:not(.Gallery) {
+[class*='u-richtext'] > .u-full:not(.Gallery) + .u-full:not(.Gallery),
+[class*='u-richtext'] > .u-full:not(.Gallery) + a[name] + .u-full:not(.Gallery) {
   margin-top: -2rem;
 
   @media #{$mq-lg} {
     margin-top: -3rem;
   }
 }
-

--- a/src/app/scheduler/index.js
+++ b/src/app/scheduler/index.js
@@ -10,7 +10,7 @@ const BUDGETED_MILLISECONDS_PER_FRAME = 12;
 
 const subscribers = [];
 const queue = [];
-let client = null
+let client = null;
 let hasStarted;
 
 function flush() {
@@ -81,7 +81,7 @@ function onResize(event) {
 }
 
 function invalidateClient() {
-  enqueue(onResize.bind(null, null, true));
+  enqueue(onResize.bind(null, true));
 }
 
 function start() {


### PR DESCRIPTION
This change instructs `VideoPlayer` components to swap out custom controls for native ones and disable inline playback on short screens (usually phones in landscape orientation). This is implemented as an extra hook into the scheduler that toggles the UI changes for each non-ambient video player dependent on `matchMedia` comparison.

Also in this changeset:
* CSS custom property fallback values
* A fix for exiting fullscreen mode which sometimes throws an error if there was no active element in the underlying document to re-focus.
* The `Nav` bar is no longer shown when the `MasterGallery` is active, and application of its z-index is now conditional so it doesn't appear on top of other elements in fullscreen mode.
* `invalidateClient` in the scheduler now correctly passes arguments to `onResize`.