### PR TITLE
Added support for using `init-interactive` elements as Header media

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "odyssey",
-  "version": "2.4.0",
+  "version": "2.10.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4580,7 +4580,7 @@
       "dev": true
     },
     "inn-abcdatetime-lib": {
-      "version": "git+ssh://git@stash.abc-dev.net.au:7999/news/news-abcdatetime-lib#9a1c41a840bab6fc79a18785e0fbb77653ea5dfe"
+      "version": "git+ssh://git@stash.abc-dev.net.au:7999/news/news-abcdatetime-lib#e8370ee6e224fa49ecb0bd4ab987781e20715cdf"
     },
     "internal-ip": {
       "version": "1.2.0",

--- a/src/app/components/Header/index.js
+++ b/src/app/components/Header/index.js
@@ -18,6 +18,7 @@ function Header({
   meta = {},
   videoElOrId,
   imgEl,
+  interactiveEl,
   ratios = {},
   isDark,
   isLayered,
@@ -29,7 +30,7 @@ function Header({
     'Header',
     {
       'is-dark': meta.isDarkMode || isDark,
-      'is-layered': isLayered && (imgEl || videoElOrId)
+      'is-layered': isLayered && (imgEl || videoElOrId || interactiveEl)
     },
     'u-full'
   );
@@ -76,6 +77,8 @@ function Header({
 
       invalidateClient();
     });
+  } else if (interactiveEl) {
+    mediaEl = interactiveEl.cloneNode(true);
   }
 
   const clonedMiscContentEls = miscContentEls.map(el => {
@@ -139,9 +142,7 @@ function Header({
   const headerEl = html`
     <div class="${className}">
       ${mediaEl
-        ? html`<div class="Header-media${isLayered ? ' u-parallax' : ''}">
-        ${mediaEl}
-      </div>`
+        ? html`<div class="Header-media${isLayered && mediaEl.tagName !== 'DIV' ? ' u-parallax' : ''}">${mediaEl}</div>`
         : null}
       ${headerContentEl}
     </div>
@@ -191,8 +192,9 @@ function transformSection(section, meta) {
       let videoEl;
       let videoId;
       let imgEl;
+      let interactiveEl;
 
-      if (!isNoMedia && !config.videoElOrId && !config.imgEl && isElement(node)) {
+      if (!isNoMedia && !config.videoElOrId && !config.imgEl && !config.interactiveEl && isElement(node)) {
         classList = node.className.split(' ');
         videoEl = $('video', node);
 
@@ -213,12 +215,14 @@ function transformSection(section, meta) {
 
             if (imgEl) {
               config.imgEl = imgEl;
+            } else if (classList.indexOf('init-interactive') > -1) {
+              config.interactiveEl = interactiveEl = node;
             }
           }
         }
       }
 
-      if (!videoEl && !videoId && !imgEl && isElement(node) && trim(node.textContent).length > 0) {
+      if (!videoEl && !videoId && !imgEl && !interactiveEl && isElement(node) && trim(node.textContent).length > 0) {
         config.miscContentEls.push(node);
       }
 


### PR DESCRIPTION
If an `<div class="init-interactive" ... >` is the first 'media' inside a `#header` then it will use that as the background media.

Note: If the header is set to `layered` the `u-parallax` class won't be attached like normal. It is assumed the interactive handles it's own sizing/positioning.