### PR TITLE
Meta infoSource optional link

### DIFF
--- a/src/app/components/Header/index.js
+++ b/src/app/components/Header/index.js
@@ -90,7 +90,9 @@ function Header({
   });
 
   const clonedBylineNodes = meta.bylineNodes ? meta.bylineNodes.map(node => node.cloneNode(true)) : null;
-  const infoSource = meta.infoSource ? html`<a href="${meta.infoSource.url}">${meta.infoSource.name}</a>` : null;
+  const infoSource = meta.infoSource
+    ? meta.infoSource.url ? html`<a href="${meta.infoSource.url}">${meta.infoSource.name}</a>` : meta.infoSource.name
+    : null;
   const updated = typeof meta.updated === 'string' ? meta.updated : formatUIGRelative(meta.updated);
   const published = typeof meta.published === 'string' ? meta.published : formatUIGRelative(meta.published);
 
@@ -110,9 +112,9 @@ function Header({
         : null,
       infoSource
         ? html`
-      <div class="Header-infoSource Header-infoSource--${slug(meta.infoSource.name)}">
+      <p class="Header-infoSource Header-infoSource--${slug(meta.infoSource.name)}">
         ${infoSource}
-      </div>
+      </p>
     `
         : null,
       updated

--- a/src/app/meta/index.js
+++ b/src/app/meta/index.js
@@ -66,6 +66,13 @@ function getInfoSource() {
 
     if (infoSourceMetaContent) {
       infoSourceLinkEl = $(`a[title="${infoSourceMetaContent}"]`);
+    } else {
+      const infoSourceEl = $(SELECTORS.INFO_SOURCE);
+
+      if (infoSourceEl) {
+        infoSourceLinkEl = document.createElement('a');
+        infoSourceLinkEl.textContent = infoSourceEl.textContent;
+      }
     }
   }
 

--- a/src/app/meta/index.js
+++ b/src/app/meta/index.js
@@ -79,7 +79,7 @@ function getInfoSource() {
   return infoSourceLinkEl
     ? {
         name: trim(infoSourceLinkEl.textContent),
-        url: infoSourceLinkEl.href
+        url: infoSourceLinkEl.getAttribute('href')
       }
     : null;
 }


### PR DESCRIPTION
This issue was raised to address our "Interactive Digital Storytelling team" link in Odyssey headers on the desktop site* going to the current page (because the pre-transform DOM element was an anchor element with an empty href property.

Now link-less infoSources will appear as plaintext.

*This also fixed a bug where the mobile site wasn't rendering link-less infoSources at all.

Closes #14 