### PR TITLE
Add VideoPlayer title property

### DIFF
--- a/src/app/components/Caption/index.js
+++ b/src/app/components/Caption/index.js
@@ -14,7 +14,7 @@ function Caption({ url, text, attribution }) {
 
   return html`
     <p class="Caption" title="${text}${attribution ? ` (${attribution})` : ''}">
-      ${url ? html`<a href="${url}">${text}</a>` : text}
+      ${url ? html`<a href="${url}">${text}</a>` : html`<span>${text}</span>`}
       ${attribution ? html`<em class="Caption-attribution">${attribution}</em>` : null}
     </p>
   `;

--- a/src/app/components/VideoEmbed/index.js
+++ b/src/app/components/VideoEmbed/index.js
@@ -43,6 +43,9 @@ function transformEl(el) {
     return;
   }
 
+  const captionEl = Caption.createFromEl(el);
+  const title = captionEl ? captionEl.children[0].textContent : null;
+
   const configSC = grabConfigSC(el);
   const [, alignment] = configSC.match(ALIGNMENT_PATTERN) || [];
 
@@ -61,6 +64,7 @@ function transformEl(el) {
 
   const videoPlayerOptions = {
     ratios: getRatios(configSC),
+    title,
     isAlwaysHQ: options.isCover || options.isFull,
     isAmbient: configSC.indexOf('ambient') > -1,
     isLoop: configSC.indexOf('loop') > -1,
@@ -84,7 +88,7 @@ function transformEl(el) {
     VideoEmbed(
       Object.assign(options, {
         videoPlayerEl: videoPlayerPlaceholderEl,
-        captionEl: Caption.createFromEl(el)
+        captionEl
       })
     )
   );

--- a/src/app/components/VideoPlayer/index.js
+++ b/src/app/components/VideoPlayer/index.js
@@ -22,12 +22,23 @@ const STEP_SECONDS = 5;
 const DEFAULT_RATIO = '16x9';
 
 const players = [];
+let nextUntitledVideoCharCode = 65;
 
 function hasAudio(el) {
   return el.mozHasAudio || !!el.webkitAudioDecodedByteCount || !!(el.audioTracks && el.audioTracks.length);
 }
 
-function VideoPlayer({ ratios = {}, posterURL, sources = [], isAmbient, isAlwaysHQ, isLoop, isMuted, scrollplayPct }) {
+function VideoPlayer({
+  posterURL,
+  ratios = {},
+  sources = [],
+  title,
+  isAmbient,
+  isAlwaysHQ,
+  isLoop,
+  isMuted,
+  scrollplayPct
+}) {
   ratios = {
     sm: ratios.sm || DEFAULT_RATIO,
     md: ratios.md || DEFAULT_RATIO,
@@ -45,7 +56,11 @@ function VideoPlayer({ ratios = {}, posterURL, sources = [], isAmbient, isAlways
     isMuted = true;
   }
 
-  const videoEl = html`<video preload="none" tabindex="-1"></video>`;
+  if (!title) {
+    title = String.fromCharCode(nextUntitledVideoCharCode++);
+  }
+
+  const videoEl = html`<video preload="none" tabindex="-1" aria-label="${title}"></video>`;
 
   toggleBooleanAttributes(videoEl, {
     loop: isLoop,
@@ -301,7 +316,7 @@ function VideoPlayer({ ratios = {}, posterURL, sources = [], isAmbient, isAlways
   if (!isAmbient) {
     playbackEl = html`<button
       class="VideoPlayer-playback"
-      aria-label="Play"
+      aria-label="${`Play video, ${title}`}"
       onkeydown=${whenKeyIn([37, 38, 39, 40], steppingKeyDown)}
       onkeyup=${whenKeyIn([37, 38, 39, 40], steppingKeyUp)}
       onclick=${player.togglePlayback}

--- a/src/app/components/VideoPlayer/stats.js
+++ b/src/app/components/VideoPlayer/stats.js
@@ -49,7 +49,7 @@ function sendWebtrendsClipEvent(el, eventName) {
   const args = {
     'DCS.dcsuri': window.location.pathname + '/' + el.src.replace(/.*\//, ''),
     'WT.clip_ev': eventName,
-    'WT.clip_n': document.title, // TODO: Video title
+    'WT.clip_n': el.getAttribute('aria-label') || document.title,
     'WT.clip_t': WT__CLIP_T,
     'WT.dl': WT__DL,
     'WT.ti': document.title


### PR DESCRIPTION
This adds a `title` property to `VideoPlayer` components which can be used to better label their play buttons for assistive technologies, and enable unique title reporting to Webtrends.

If you don't pass the property, a unique title is created (a simple incrementing uppercase ASCII letter until we come up with something better).

The change includes the Webtrends tracking correction, as well as a slight modification of the `VideoEmbed` component so that it can pass the `title` property to its child `VideoPlayer`.