### PR TITLE
Interactive header with misc els

### DIFF
--- a/src/app/components/Header/index.js
+++ b/src/app/components/Header/index.js
@@ -196,6 +196,7 @@ function transformSection(section, meta) {
 
   // See if we have an init-interactive in the header
   const interactiveNode = candidateNodes.filter(node => {
+    if (!node.className) return false;
     const classList = node.className.split(' ');
     return classList.indexOf('init-interactive') > -1 || node.querySelector('[class^="init-interactive"]');
   })[0];

--- a/src/app/components/Header/index.js
+++ b/src/app/components/Header/index.js
@@ -210,7 +210,7 @@ function transformSection(section, meta) {
       let interactiveEl;
 
       // If we found an init-interactive then it takes over being the header media
-      if (!isNoMedia && interactiveNode) {
+      if (!isNoMedia && !config.interactiveEl && interactiveNode) {
         config.interactiveEl = interactiveEl = interactiveNode;
       }
 


### PR DESCRIPTION
Previously, having an interactive in the header would erroneously ignore any paragraph nodes for use as `misc-els`.