### PR TITLE
VideoPlayer high resolution source selection logic change

### DIFF
--- a/src/app/components/Block/index.js
+++ b/src/app/components/Block/index.js
@@ -76,7 +76,6 @@ function Block({
         const replacementMediaEl = VideoPlayer(
           Object.assign(metadata, {
             ratios,
-            isAlwaysHQ: true,
             isAmbient: true
           })
         );

--- a/src/app/components/Header/index.js
+++ b/src/app/components/Header/index.js
@@ -77,7 +77,6 @@ function Header({
         const replacementMediaEl = VideoPlayer(
           Object.assign(metadata, {
             ratios,
-            isAlwaysHQ: true,
             isAmbient: true
           })
         );

--- a/src/app/components/VideoEmbed/index.js
+++ b/src/app/components/VideoEmbed/index.js
@@ -67,7 +67,6 @@ function transformEl(el) {
   const playerOptions = {
     ratios: getRatios(configSC),
     title,
-    isAlwaysHQ: options.isCover || options.isFull,
     isAmbient: configSC.indexOf('ambient') > -1,
     isLoop: configSC.indexOf('loop') > -1,
     isMuted: configSC.indexOf('muted') > -1,

--- a/src/app/components/VideoPlayer/index.js
+++ b/src/app/components/VideoPlayer/index.js
@@ -67,7 +67,14 @@ function VideoPlayer({ posterURL, ratios = {}, sources = [], title, isAmbient, i
     videoEl.style.backgroundImage = `url("${resize({ url: posterURL })}")`;
   }
 
-  const source = sources[sources.length > 1 && window.matchMedia(MQ.SM).matches ? 1 : 0];
+  // If we're on mobile, and have more than one high resolution source, use the second
+  // highest; otherwise, use the first source (of any resolution).
+  // Note: Only Phase 1 (Desktop) sources have width/height defined, making it the
+  // only template that can differentiate its high resolution sources.
+  const highResSources = sources.filter(source => source.width >= 1024);
+  const source = (highResSources.length ? highResSources : sources)[
+    highResSources.length > 1 && window.matchMedia(MQ.SM).matches ? 1 : 0
+  ];
 
   if (source) {
     videoEl.src = source.src;
@@ -399,7 +406,9 @@ function getMetadata(videoElOrId, callback) {
 function formatSources(sources, sortProp = 'bitrate') {
   return sources.sort((a, b) => +b[sortProp] - +a[sortProp]).map(source => ({
     src: source.src || source.url,
-    type: source.type || source.contentType
+    type: source.type || source.contentType,
+    width: +source.width || 0,
+    height: +source.height || 0
   }));
 }
 

--- a/src/app/components/VideoPlayer/index.js
+++ b/src/app/components/VideoPlayer/index.js
@@ -25,17 +25,7 @@ function hasAudio(el) {
   return el.mozHasAudio || !!el.webkitAudioDecodedByteCount || !!(el.audioTracks && el.audioTracks.length);
 }
 
-function VideoPlayer({
-  posterURL,
-  ratios = {},
-  sources = [],
-  title,
-  isAmbient,
-  isAlwaysHQ,
-  isLoop,
-  isMuted,
-  scrollplayPct
-}) {
+function VideoPlayer({ posterURL, ratios = {}, sources = [], title, isAmbient, isLoop, isMuted, scrollplayPct }) {
   ratios = {
     sm: ratios.sm || DEFAULT_RATIO,
     md: ratios.md || DEFAULT_RATIO,
@@ -77,7 +67,7 @@ function VideoPlayer({
     videoEl.style.backgroundImage = `url("${resize({ url: posterURL })}")`;
   }
 
-  const source = sources[!isAlwaysHQ && sources.length > 1 && window.matchMedia(MQ.SM).matches ? 1 : 0];
+  const source = sources[sources.length > 1 && window.matchMedia(MQ.SM).matches ? 1 : 0];
 
   if (source) {
     videoEl.src = source.src;


### PR DESCRIPTION
The standard "high resolution" video source we get from CoreMedia is currently 1024x576px.

Originally we were loading that source on desktop, and the next-best source on mobile (which was only 512px wide, and looked terrible on full-screen cover videos, so we changed the logic to always use the 1024px wide source on mobile, except for inline players.

This resulted in a lot of wasted video pixels due to Odyssey's virtual cropping of 16:9 video to 3:4/1:1, so we began experimenting with alternative aspect ratio _sources_ (and higher resolution video across the board).

This change allows us to filter the available sources, so that mobile devices only use the next-best video if we can be sure it is also high resolution (which we'll be putting into CoreMedia as a square crop, by convention).