### PR TITLE
Maximum media height in Header component.

### DIFF
--- a/src/app/components/Header/index.scss
+++ b/src/app/components/Header/index.scss
@@ -32,6 +32,13 @@
   position: relative;
   background-color: $color-black;
 
+  :not(.is-layered) > & {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    max-height: calc(85vh - #{$abc-nav-height + $size-bar});
+  }
+
   .is-layered > & {
     position: absolute;
     top: 0;


### PR DESCRIPTION
In Headers where the content follows the media, ensure that the content always peeks (i.e. the media shouldn't cover the entire height of the page).

It's important that the reader always sees (even a part of) the story title when they arrive on an Odyssey story, which is currently being pushed beyond the 'fold' on larger screens where 16:9 images/video take up the entire viewport.

This change effectively forces the media aspect ratio to increase (artificially) on larger devices, with equal cropping above and below.