### PR TITLE
So long, old #anchors

### DIFF
--- a/src/app/components/Gallery/index.js
+++ b/src/app/components/Gallery/index.js
@@ -13,7 +13,7 @@ const Caption = require('../Caption');
 const Picture = require('../Picture');
 require('./index.scss');
 
-const MOSAIC_ROW_LENGTHS_PATTERN = /(?:tiled|mosaic)(\d+)/;
+const MOSAIC_ROW_LENGTHS_PATTERN = /mosaic(\d+)/;
 const PCT_PATTERN = /(-?[0-9\.]+)%/;
 const SWIPE_THRESHOLD = 25;
 const AXIS_THRESHOLD = 5;

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -195,6 +195,19 @@ function app() {
   // Expose API, then notify interested parties
   window.__ODYSSEY__ = api;
   window.dispatchEvent(new CustomEvent('odyssey:api', { detail: api }));
+
+  // Notify console of deprecated anchors
+  setTimeout(() => {
+    const deprecated = {};
+
+    getMarkers(['image', 'video', 'cover', 'endcover']).forEach(marker => (deprecated[`#${marker.name}`] = true));
+
+    const keys = Object.keys(deprecated);
+
+    if (keys) {
+      console.debug(`[Odyssey] Deprecated anchors used: ${Object.keys(deprecated).join()}`);
+    }
+  }, 0);
 }
 
 module.exports = app;

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -191,12 +191,12 @@ function app() {
   setTimeout(() => {
     const deprecated = {};
 
-    getMarkers(['image', 'video', 'cover', 'endcover']).forEach(marker => (deprecated[`#${marker.name}`] = true));
+    getMarkers(['image', 'video', 'cover', 'gallerytiled']).forEach(marker => (deprecated[`#${marker.name}`] = true));
 
     const keys = Object.keys(deprecated);
 
     if (keys.length) {
-      console.debug(`[Odyssey] Deprecated anchors used: ${Object.keys(deprecated).join()}`);
+      console.debug(`[Odyssey] Deprecated anchors used: ${Object.keys(deprecated).join(', ')}`);
     }
   }, 5000);
 }

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -204,7 +204,7 @@ function app() {
 
     const keys = Object.keys(deprecated);
 
-    if (keys) {
+    if (keys.length) {
       console.debug(`[Odyssey] Deprecated anchors used: ${Object.keys(deprecated).join()}`);
     }
   }, 5000);

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -44,15 +44,7 @@ function app() {
   let hasHeader = false;
 
   // Transform sections
-  getSections([
-    'header',
-    'remove',
-    'block',
-    'cover', // deprecated - use 'block'
-    'gallery',
-    'mosaic',
-    'pull'
-  ]).forEach(section => {
+  getSections(['header', 'remove', 'block', 'gallery', 'mosaic', 'pull']).forEach(section => {
     switch (section.name) {
       case 'header':
         hasHeader = true;
@@ -62,7 +54,6 @@ function app() {
         detachAll([section.startNode, section.endNode].concat(section.betweenNodes));
         break;
       case 'block':
-      case 'cover':
         Block.transformSection(section);
         break;
       case 'gallery':

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -207,7 +207,7 @@ function app() {
     if (keys) {
       console.debug(`[Odyssey] Deprecated anchors used: ${Object.keys(deprecated).join()}`);
     }
-  }, 0);
+  }, 5000);
 }
 
 module.exports = app;

--- a/src/app/utils/anchors.js
+++ b/src/app/utils/anchors.js
@@ -2,20 +2,19 @@
 const { MOCK_ELEMENT } = require('../../constants');
 const { $$, detach, detachAll, isElement, substitute } = require('./dom');
 
+const CONFIG_ANCHOR_NAME = 'config';
+
 function grabConfigSC(el) {
   const prevEl = el.previousElementSibling || MOCK_ELEMENT;
   const prevElName = prevEl.getAttribute('name') || '';
-  let configSC;
 
-  // TODO: Convert #image and #video in all stories to #config
-  ['config', 'image', 'video'].some(name => {
-    if (prevElName.indexOf(name) === 0) {
-      configSC = prevElName.slice(name.length);
-      detach(prevEl);
-    }
-  });
+  if (prevElName.indexOf(CONFIG_ANCHOR_NAME) !== 0) {
+    return '';
+  }
 
-  return configSC || '';
+  detach(prevEl);
+
+  return prevElName.slice(CONFIG_ANCHOR_NAME.length);
 }
 
 function _substituteSectionWith(el, remainingBetweenNodes) {


### PR DESCRIPTION
This series of commits removes deprecated anchors used during the development of Odyssey (back when we called it Narricle).

Specifically:
* `#cover`/`#endcover` is no longer an alias for `#block`/`#endblock`
* `#gallerytiled`/`#endgallery` is no longer an alias for `#mosaic`/`#endmosaic`
* `#image` & `#video` are no longer aliases for `#config` when preceding their respective embeds

**NOTE**: After this change is released, these old anchors will stop working.

I've already done the work in Core to remove usage of these old anchors in every Odyssey story (even drafts). Please check any snippets you're storing in Editorial Notes (or outside Core) to avoid accidentally dropping old anchors into new stories.

To help you catch accidental usage, Odyssey now logs them to the browser console, e.g.:

```
＞ [Odyssey] Deprecated anchors used: #image, #cover
```

The check is performed 5 seconds after page load, just in case you happen to be using those anchor names in other apps on the same page (giving you time to remove them from the DOM).

> I'm making this change now, so I can re-purpose the `#video` anchor as a way to load ambient video without it being syndicated anywhere or appearing in the app—we're experimenting with supplying ambient video backgrounds as a progressive enhancement of images (which we want to embed normally to those _are_ syndicated). Expect that further work to also be carried out on this branch.