### PR TITLE
New #video embed marker; alternative Header/Block media

### DIFF
--- a/src/app/components/Block/index.js
+++ b/src/app/components/Block/index.js
@@ -144,8 +144,13 @@ function transformSection(section) {
   const isDocked = section.configSC.indexOf('docked') > -1;
   const isPiecemeal = section.configSC.indexOf('piecemeal') > -1;
   const isLight = section.configSC.indexOf('light') > -1;
+  const shouldSupplant = section.configSC.indexOf('supplant') > -1;
   const [, alignment] = section.configSC.match(ALIGNMENT_PATTERN) || [];
   let sourceMediaEl;
+
+  if (shouldSupplant && section.betweenNodes.length) {
+    detach(section.betweenNodes.shift());
+  }
 
   const config = section.betweenNodes.reduce(
     (config, node) => {

--- a/src/app/components/Block/index.js
+++ b/src/app/components/Block/index.js
@@ -4,7 +4,7 @@ const html = require('bel');
 const url2cmid = require('util-url2cmid');
 
 // Ours
-const { ALIGNMENT_PATTERN, IS_PREVIEW } = require('../../../constants');
+const { ALIGNMENT_PATTERN, VIDEO_MARKER_PATTERN, IS_PREVIEW } = require('../../../constants');
 const { enqueue, invalidateClient, subscribe } = require('../../scheduler');
 const { $, detach, isElement, substitute } = require('../../utils/dom');
 const { getRatios, trim } = require('../../utils/misc');
@@ -21,6 +21,7 @@ function Block({
   isLight,
   alignment,
   videoId,
+  isVideoMarker,
   isVideoYouTube,
   imgEl,
   ratios = {},
@@ -68,7 +69,7 @@ function Block({
       });
     } else {
       mediaEl = html`<div></div>`;
-      VideoPlayer.getMetadata(videoId, (err, metadata) => {
+      VideoPlayer[`getMetadata${isVideoMarker ? 'FromDetailPage' : ''}`](videoId, (err, metadata) => {
         if (err) {
           return;
         }
@@ -155,9 +156,10 @@ function transformSection(section) {
       if (!config.videoId && !config.imgEl && isElement(node)) {
         classList = node.className.split(' ');
 
-        if (node.name && node.name.indexOf('youtube') === 0) {
-          videoId = node.name.split('youtube')[1];
-          config.isVideoYouTube = true;
+        if (node.name && !!node.name.match(VIDEO_MARKER_PATTERN)) {
+          config.isVideoMarker = true;
+          config.isVideoYouTube = node.name.split('youtube')[1];
+          config.videoElOrId = videoId = node.name.match(VIDEO_MARKER_PATTERN)[1];
         } else {
           videoId =
             ((classList.indexOf('inline-content') > -1 && classList.indexOf('video') > -1) ||

--- a/src/app/components/Header/index.js
+++ b/src/app/components/Header/index.js
@@ -5,7 +5,7 @@ const { formatUIGRelative } = require('inn-abcdatetime-lib');
 const url2cmid = require('util-url2cmid');
 
 // Ours
-const { IS_PREVIEW, MS_VERSION } = require('../../../constants');
+const { IS_PREVIEW, MS_VERSION, VIDEO_MARKER_PATTERN } = require('../../../constants');
 const { enqueue, invalidateClient, subscribe } = require('../../scheduler');
 const { $, isElement, prepend, substitute } = require('../../utils/dom');
 const { dePx, getRatios, slug, trim } = require('../../utils/misc');
@@ -18,6 +18,7 @@ require('./index.scss');
 function Header({
   meta = {},
   videoElOrId,
+  isVideoMarker,
   isVideoYouTube,
   imgEl,
   interactiveEl,
@@ -69,7 +70,7 @@ function Header({
       }
     } else {
       mediaEl = html`<div></div>`;
-      VideoPlayer.getMetadata(videoElOrId, (err, metadata) => {
+      VideoPlayer[`getMetadata${isVideoMarker ? 'FromDetailPage' : ''}`](videoElOrId, (err, metadata) => {
         if (err) {
           return;
         }
@@ -233,13 +234,10 @@ function transformSection(section, meta) {
 
         if (videoEl) {
           config.videoElOrId = videoEl;
-        } else if (node.name && node.name.indexOf('youtube') === 0) {
-          videoId = node.name.split('youtube')[1];
-
-          if (videoId) {
-            config.isVideoYouTube = true;
-            config.videoElOrId = videoId;
-          }
+        } else if (node.name && !!node.name.match(VIDEO_MARKER_PATTERN)) {
+          config.isVideoMarker = true;
+          config.isVideoYouTube = node.name.split('youtube')[1];
+          config.videoElOrId = videoId = node.name.match(VIDEO_MARKER_PATTERN)[1];
         } else {
           videoId =
             ((classList.indexOf('inline-content') > -1 && classList.indexOf('video') > -1) ||

--- a/src/app/components/Header/index.js
+++ b/src/app/components/Header/index.js
@@ -7,7 +7,7 @@ const url2cmid = require('util-url2cmid');
 // Ours
 const { IS_PREVIEW, MS_VERSION, VIDEO_MARKER_PATTERN } = require('../../../constants');
 const { enqueue, invalidateClient, subscribe } = require('../../scheduler');
-const { $, isElement, prepend, substitute } = require('../../utils/dom');
+const { $, detach, isElement, prepend, substitute } = require('../../utils/dom');
 const { dePx, getRatios, slug, trim } = require('../../utils/misc');
 const Picture = require('../Picture');
 const UParallax = require('../UParallax');
@@ -202,11 +202,16 @@ function transformSection(section, meta) {
   const isLayered = section.configSC.indexOf('layered') > -1;
   const isNoMedia = section.configSC.indexOf('nomedia') > -1;
   const isKicker = section.configSC.indexOf('kicker') > -1;
+  const shouldSupplant = section.configSC.indexOf('supplant') > -1;
 
   let candidateNodes = section.betweenNodes;
 
   if (!isNoMedia && meta.relatedMedia != null) {
     candidateNodes = [meta.relatedMedia.cloneNode(true)].concat(candidateNodes);
+  }
+
+  if (shouldSupplant && candidateNodes.length) {
+    detach(candidateNodes.shift());
   }
 
   // See if we have an init-interactive in the header

--- a/src/app/components/VideoEmbed/index.js
+++ b/src/app/components/VideoEmbed/index.js
@@ -4,7 +4,7 @@ const html = require('bel');
 const url2cmid = require('util-url2cmid');
 
 // Ours
-const { IS_PREVIEW, ALIGNMENT_PATTERN } = require('../../../constants');
+const { IS_PREVIEW, ALIGNMENT_PATTERN, VIDEO_MARKER_PATTERN, SCROLLPLAY_PCT_PATTERN } = require('../../../constants');
 const { invalidateClient } = require('../../scheduler');
 const { grabConfigSC } = require('../../utils/anchors');
 const { $, $$, substitute } = require('../../utils/dom');
@@ -13,9 +13,6 @@ const Caption = require('../Caption');
 const VideoPlayer = require('../VideoPlayer');
 const YouTubePlayer = require('../YouTubePlayer');
 require('./index.scss');
-
-const VIDEO_ID_PATTERN = /(?:video|youtube)(\w+)/;
-const SCROLLPLAY_PCT_PATTERN = /scrollplay(\d+)/;
 
 function VideoEmbed({ playerEl, captionEl, alignment, isFull, isCover, isAnon }) {
   if (isCover) {
@@ -39,8 +36,8 @@ function VideoEmbed({ playerEl, captionEl, alignment, isFull, isCover, isAnon })
 }
 
 function transformEl(el) {
-  const isMarker = el.name && !!el.name.match(VIDEO_ID_PATTERN);
-  const videoId = isMarker ? el.name.match(VIDEO_ID_PATTERN)[1] : url2cmid($('a', el).getAttribute('href'));
+  const isMarker = el.name && !!el.name.match(VIDEO_MARKER_PATTERN);
+  const videoId = isMarker ? el.name.match(VIDEO_MARKER_PATTERN)[1] : url2cmid($('a', el).getAttribute('href'));
 
   if (!videoId) {
     return;

--- a/src/app/components/VideoEmbed/index.js
+++ b/src/app/components/VideoEmbed/index.js
@@ -14,6 +14,7 @@ const VideoPlayer = require('../VideoPlayer');
 const YouTubePlayer = require('../YouTubePlayer');
 require('./index.scss');
 
+const VIDEO_ID_PATTERN = /(?:video|youtube)(\w+)/;
 const SCROLLPLAY_PCT_PATTERN = /scrollplay(\d+)/;
 
 function VideoEmbed({ playerEl, captionEl, alignment, isFull, isCover, isAnon }) {
@@ -38,14 +39,15 @@ function VideoEmbed({ playerEl, captionEl, alignment, isFull, isCover, isAnon })
 }
 
 function transformEl(el) {
-  const isYouTube = el.name && el.name.indexOf('youtube') === 0;
-  const videoId = isYouTube ? el.name.split('youtube')[1] : url2cmid($('a', el).getAttribute('href'));
+  const isMarker = el.name && !!el.name.match(VIDEO_ID_PATTERN);
+  const videoId = isMarker ? el.name.match(VIDEO_ID_PATTERN)[1] : url2cmid($('a', el).getAttribute('href'));
 
   if (!videoId) {
     return;
   }
 
-  const captionEl = Caption.createFromEl(el);
+  const isYouTube = isMarker && el.name.indexOf('youtube') === 0;
+  const captionEl = !isMarker ? Caption.createFromEl(el) : null;
   const title = captionEl ? captionEl.children[0].textContent : null;
 
   const configSC = grabConfigSC(el);
@@ -76,7 +78,7 @@ function transformEl(el) {
   const playerEl = isYouTube ? YouTubePlayer(Object.assign(playerOptions, { videoId })) : html`<div></div>`;
 
   if (!isYouTube) {
-    VideoPlayer.getMetadata(videoId, (err, metadata) => {
+    VideoPlayer[`getMetadata${isMarker ? 'FromDetailPage' : ''}`](videoId, (err, metadata) => {
       if (err) {
         return;
       }
@@ -89,5 +91,10 @@ function transformEl(el) {
   substitute(el, VideoEmbed(Object.assign(options, { playerEl, captionEl })));
 }
 
+function transformMarker(marker) {
+  return transformEl(marker.node);
+}
+
 module.exports = VideoEmbed;
 module.exports.transformEl = transformEl;
+module.exports.transformMarker = transformMarker;

--- a/src/app/components/VideoPlayer/index.js
+++ b/src/app/components/VideoPlayer/index.js
@@ -2,28 +2,21 @@
 const html = require('bel');
 const playInline = require('iphone-inline-video').default;
 const raf = require('raf');
-const url2cmid = require('util-url2cmid');
-const xhr = require('xhr');
 
 // Ours
-const { CSS_URL, IS_IOS, MQ, MS_VERSION, SMALLEST_IMAGE } = require('../../../constants');
+const { IS_IOS, MQ, MS_VERSION, SMALLEST_IMAGE } = require('../../../constants');
 const { getNextUntitledMediaCharCode, registerPlayer, forEachPlayer } = require('../../media');
-const { getMeta } = require('../../meta');
 const { enqueue, subscribe } = require('../../scheduler');
-const { $, $$, append, isElement, toggleAttribute, toggleBooleanAttributes } = require('../../utils/dom');
+const { toggleAttribute, toggleBooleanAttributes } = require('../../utils/dom');
 const { resize } = require('../Picture');
 const VideoControls = require('../VideoControls');
 const { trackProgress } = require('./stats');
+const { getMetadata, getRemoteMetadata, hasAudio } = require('./utils');
 require('./index.scss');
 
-const NEWLINES_PATTERN = /[\n\r]/g;
 const FUZZY_INCREMENT_FPS = 30;
 const FUZZY_INCREMENT_INTERVAL = 1000 / FUZZY_INCREMENT_FPS;
 const DEFAULT_RATIO = '16x9';
-
-function hasAudio(el) {
-  return el.mozHasAudio || !!el.webkitAudioDecodedByteCount || !!(el.audioTracks && el.audioTracks.length);
-}
 
 function VideoPlayer({ posterURL, ratios = {}, sources = [], title, isAmbient, isLoop, isMuted, scrollplayPct }) {
   ratios = {
@@ -287,131 +280,6 @@ function toggleMutePreference(event) {
   });
 }
 
-function getMetadata(videoElOrId, callback) {
-  let wasCalled;
-
-  function done(err, metadata) {
-    if (!wasCalled) {
-      wasCalled = true;
-      raf(() => {
-        callback(err, metadata);
-      });
-    }
-  }
-
-  if (isElement(videoElOrId)) {
-    if (videoElOrId.className.indexOf('jw-') > -1) {
-      // JWPLayer <video> with src attribute and nearby element with poster as a background-image
-      done(null, {
-        posterURL: (videoElOrId.parentElement.nextElementSibling.style.backgroundImage.match(CSS_URL) || [, ''])[1],
-        sources: formatSources([videoElOrId])
-      });
-    } else {
-      // <video> with poster attribute and <source> children
-      done(null, {
-        posterURL: videoElOrId.poster,
-        sources: formatSources($$('source', videoElOrId))
-      });
-    }
-  } else if ('WCMS' in window) {
-    // Phase 2
-    // * Poster & sources are nested inside global `WCMS` object
-
-    Object.keys(WCMS.pluginCache.plugins.videoplayer).some(key => {
-      const config = WCMS.pluginCache.plugins.videoplayer[key][0].videos[0];
-
-      if (config.url.indexOf(videoElOrId) > -1) {
-        done(null, {
-          posterURL: config.thumbnail.replace('-thumbnail', '-large'),
-          sources: formatSources(config.sources, 'label')
-        });
-
-        return true;
-      }
-    });
-  } else if ('inlineVideoData' in window) {
-    // Phase 1 (Standard)
-    // * Poster may be inferred from original embed's partial jwplayer transform
-    // * Sources are nested inside global `inlineVideoData` object
-
-    const relatedMedia = getMeta().relatedMedia;
-
-    $$('.inline-content.video[data-inline-video-data-index]')
-      .concat(relatedMedia ? [relatedMedia] : [])
-      .some(el => {
-        if ($(`[href*="/${videoElOrId}"]`, el)) {
-          const posterEl = $('img', el) || $('.inline-video, .jwplayer-video', el);
-
-          done(null, {
-            posterURL: posterEl ? (posterEl.style.backgroundImage.match(CSS_URL) || [, posterEl.src])[1] : null,
-            sources: formatSources(window.inlineVideoData[el.getAttribute('data-inline-video-data-index')])
-          });
-
-          return true;
-        }
-      });
-  } else {
-    // Phase 1 (Mobile):
-    // * Doesn't embed video; only teases to it.
-    // * Must fetch video detail page (Phase 1 always fetches from Standard)...
-    // * ...then parse posterURL and sources, based on the page template
-
-    xhr(
-      { url: `${(window.location.origin || '').replace('mobile', 'www')}/news/${videoElOrId}?pfm=ms` },
-      (err, response, body) => {
-        if (err || response.statusCode !== 200) {
-          return done(err || new Error(response.statusCode));
-        }
-
-        const doc = new DOMParser().parseFromString(body, 'text/html');
-
-        if (body.indexOf('WCMS.pluginCache') > -1) {
-          // Phase 2
-          // * Poster can be selected from the DOM
-          // * Sources can be parsed from JS that would nest them under the global `WCMS` object
-
-          return done(null, {
-            posterURL: doc
-              .querySelector('.view-inlineMediaPlayer img')
-              .getAttribute('src')
-              .replace('-thumbnail', '-large'),
-            sources: formatSources(
-              JSON.parse(body.replace(NEWLINES_PATTERN, '').match(/"sources":(\[.*\]),"addDownload"/)[1])
-            )
-          });
-        } else if (body.indexOf('inlineVideoData') > -1) {
-          // Phase 1 (Standard)
-          // * Poster can be selected from the DOM
-          // * Sources can be parsed from JS that would nest them under the global `inlineVideoData` object
-
-          return done(null, {
-            posterURL: doc.querySelector('.inline-video img').getAttribute('src'),
-            sources: formatSources(
-              JSON.parse(
-                body
-                  .replace(NEWLINES_PATTERN, '')
-                  .match(/inlineVideoData\.push\((\[.*\])\)/)[1]
-                  .replace(/'/g, '"')
-              )
-            )
-          });
-        }
-
-        done(new Error('Unrecognised video detail page template'));
-      }
-    );
-  }
-}
-
-function formatSources(sources, sortProp = 'bitrate') {
-  return sources.sort((a, b) => +b[sortProp] - +a[sortProp]).map(source => ({
-    src: source.src || source.url,
-    type: source.type || source.contentType,
-    width: +source.width || 0,
-    height: +source.height || 0
-  }));
-}
-
 const mql = window.matchMedia('(max-height: 30rem)');
 let mqlDidMatch = mql.matches;
 
@@ -455,3 +323,4 @@ subscribe(function _checkIfVideoPlayersNeedToUpdateUIBasedOnMedia() {
 
 module.exports = VideoPlayer;
 module.exports.getMetadata = getMetadata;
+module.exports.getRemoteMetadata = getRemoteMetadata;

--- a/src/app/components/VideoPlayer/index.js
+++ b/src/app/components/VideoPlayer/index.js
@@ -11,7 +11,7 @@ const { toggleAttribute, toggleBooleanAttributes } = require('../../utils/dom');
 const { resize } = require('../Picture');
 const VideoControls = require('../VideoControls');
 const { trackProgress } = require('./stats');
-const { getMetadata, getRemoteMetadata, hasAudio } = require('./utils');
+const { getMetadata, getMetadataFromDetailPage, hasAudio } = require('./utils');
 require('./index.scss');
 
 const FUZZY_INCREMENT_FPS = 30;
@@ -323,4 +323,4 @@ subscribe(function _checkIfVideoPlayersNeedToUpdateUIBasedOnMedia() {
 
 module.exports = VideoPlayer;
 module.exports.getMetadata = getMetadata;
-module.exports.getRemoteMetadata = getRemoteMetadata;
+module.exports.getMetadataFromDetailPage = getMetadataFromDetailPage;

--- a/src/app/components/VideoPlayer/utils.js
+++ b/src/app/components/VideoPlayer/utils.js
@@ -88,17 +88,15 @@ function getMetadata(videoElOrId, callback) {
     // * Must fetch video detail page (Phase 1 always fetches from Standard)...
     // * ...then parse posterURL and sources, based on the page template
 
-    getRemoteMetadata(videoElOrId, done);
+    getMetadataFromDetailPage(videoElOrId, done);
   }
 }
-
-module.exports.getMetadata = getMetadata;
 
 function detailPageURLFromId(id) {
   return `${(window.location.origin || '').replace('mobile', 'www')}/news/${id}?pfm=ms`;
 }
 
-function getRemoteMetadata(id, callback) {
+function getMetadataFromDetailPage(id, callback) {
   xhr({ url: detailPageURLFromId(id) }, (err, response, body) => {
     if (err || response.statusCode !== 200) {
       return callback(err || new Error(response.statusCode));
@@ -142,10 +140,10 @@ function getRemoteMetadata(id, callback) {
   });
 }
 
-module.exports.getRemoteMetadata = getRemoteMetadata;
-
 function hasAudio(el) {
   return el.mozHasAudio || !!el.webkitAudioDecodedByteCount || !!(el.audioTracks && el.audioTracks.length);
 }
 
+module.exports.getMetadata = getMetadata;
+module.exports.getMetadataFromDetailPage = getMetadataFromDetailPage;
 module.exports.hasAudio = hasAudio;

--- a/src/app/components/VideoPlayer/utils.js
+++ b/src/app/components/VideoPlayer/utils.js
@@ -1,0 +1,151 @@
+// External
+const raf = require('raf');
+const xhr = require('xhr');
+
+// Ours
+const { CSS_URL } = require('../../../constants');
+const { getMeta } = require('../../meta');
+const { $, $$, isElement } = require('../../utils/dom');
+
+const NEWLINES_PATTERN = /[\n\r]/g;
+const ERROR_UNRECOGNISED = 'Unrecognised video detail page template';
+
+function formatSources(sources, sortProp = 'bitrate') {
+  return sources.sort((a, b) => +b[sortProp] - +a[sortProp]).map(source => ({
+    src: source.src || source.url,
+    type: source.type || source.contentType,
+    width: +source.width || 0,
+    height: +source.height || 0
+  }));
+}
+
+function getMetadata(videoElOrId, callback) {
+  let wasCalled;
+
+  function done(err, metadata) {
+    if (!wasCalled) {
+      wasCalled = true;
+      raf(() => {
+        callback(err, metadata);
+      });
+    }
+  }
+
+  if (isElement(videoElOrId)) {
+    if (videoElOrId.className.indexOf('jw-') > -1) {
+      // JWPLayer <video> with src attribute and nearby element with poster as a background-image
+      done(null, {
+        posterURL: (videoElOrId.parentElement.nextElementSibling.style.backgroundImage.match(CSS_URL) || [, ''])[1],
+        sources: formatSources([videoElOrId])
+      });
+    } else {
+      // <video> with poster attribute and <source> children
+      done(null, {
+        posterURL: videoElOrId.poster,
+        sources: formatSources($$('source', videoElOrId))
+      });
+    }
+  } else if ('WCMS' in window) {
+    // Phase 2
+    // * Poster & sources are nested inside global `WCMS` object
+
+    Object.keys(WCMS.pluginCache.plugins.videoplayer).some(key => {
+      const config = WCMS.pluginCache.plugins.videoplayer[key][0].videos[0];
+
+      if (config.url.indexOf(videoElOrId) > -1) {
+        done(null, {
+          posterURL: config.thumbnail.replace('-thumbnail', '-large'),
+          sources: formatSources(config.sources, 'label')
+        });
+
+        return true;
+      }
+    });
+  } else if ('inlineVideoData' in window) {
+    // Phase 1 (Standard)
+    // * Poster may be inferred from original embed's partial jwplayer transform
+    // * Sources are nested inside global `inlineVideoData` object
+
+    const relatedMedia = getMeta().relatedMedia;
+
+    $$('.inline-content.video[data-inline-video-data-index]')
+      .concat(relatedMedia ? [relatedMedia] : [])
+      .some(el => {
+        if ($(`[href*="/${videoElOrId}"]`, el)) {
+          const posterEl = $('img', el) || $('.inline-video, .jwplayer-video', el);
+
+          done(null, {
+            posterURL: posterEl ? (posterEl.style.backgroundImage.match(CSS_URL) || [, posterEl.src])[1] : null,
+            sources: formatSources(window.inlineVideoData[el.getAttribute('data-inline-video-data-index')])
+          });
+
+          return true;
+        }
+      });
+  } else {
+    // Phase 1 (Mobile):
+    // * Doesn't embed video; only teases to it.
+    // * Must fetch video detail page (Phase 1 always fetches from Standard)...
+    // * ...then parse posterURL and sources, based on the page template
+
+    getRemoteMetadata(videoElOrId, done);
+  }
+}
+
+module.exports.getMetadata = getMetadata;
+
+function detailPageURLFromId(id) {
+  return `${(window.location.origin || '').replace('mobile', 'www')}/news/${id}?pfm=ms`;
+}
+
+function getRemoteMetadata(id, callback) {
+  xhr({ url: detailPageURLFromId(id) }, (err, response, body) => {
+    if (err || response.statusCode !== 200) {
+      return callback(err || new Error(response.statusCode));
+    }
+
+    const doc = new DOMParser().parseFromString(body, 'text/html');
+
+    if (body.indexOf('WCMS.pluginCache') > -1) {
+      // Phase 2
+      // * Poster can be selected from the DOM
+      // * Sources can be parsed from JS that would nest them under the global `WCMS` object
+
+      return callback(null, {
+        posterURL: doc
+          .querySelector('.view-inlineMediaPlayer img')
+          .getAttribute('src')
+          .replace('-thumbnail', '-large'),
+        sources: formatSources(
+          JSON.parse(body.replace(NEWLINES_PATTERN, '').match(/"sources":(\[.*\]),"addDownload"/)[1])
+        )
+      });
+    } else if (body.indexOf('inlineVideoData') > -1) {
+      // Phase 1 (Standard)
+      // * Poster can be selected from the DOM
+      // * Sources can be parsed from JS that would nest them under the global `inlineVideoData` object
+
+      return callback(null, {
+        posterURL: doc.querySelector('.inline-video img').getAttribute('src'),
+        sources: formatSources(
+          JSON.parse(
+            body
+              .replace(NEWLINES_PATTERN, '')
+              .match(/inlineVideoData\.push\((\[.*\])\)/)[1]
+              .replace(/'/g, '"')
+          )
+        )
+      });
+    }
+
+    callback(new Error(ERROR_UNRECOGNISED));
+  });
+}
+
+module.exports.getRemoteMetadata = getRemoteMetadata;
+
+function hasAudio(el) {
+  return el.mozHasAudio || !!el.webkitAudioDecodedByteCount || !!(el.audioTracks && el.audioTracks.length);
+}
+
+module.exports.hasAudio = hasAudio;

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -89,7 +89,7 @@ function app() {
     .forEach(UQuote.conditionallyApply);
 
   // Transform markers
-  getMarkers(['cta', 'hr', 'series', 'share', 'youtube']).forEach(marker => {
+  getMarkers(['cta', 'hr', 'series', 'share', 'video', 'youtube']).forEach(marker => {
     let el;
 
     switch (marker.name) {
@@ -108,8 +108,9 @@ function app() {
       case 'share':
         Share.transformMarker(marker, meta.shareLinks);
         break;
+      case 'video':
       case 'youtube':
-        VideoEmbed.transformEl(marker.node);
+        VideoEmbed.transformMarker(marker);
         break;
       default:
         break;

--- a/src/constants.js
+++ b/src/constants.js
@@ -9,6 +9,8 @@ const RATIO_PATTERN = /(\d+x\d+)/;
 const SM_RATIO_PATTERN = /sm(\d+x\d+)/;
 const MD_RATIO_PATTERN = /md(\d+x\d+)/;
 const LG_RATIO_PATTERN = /lg(\d+x\d+)/;
+const VIDEO_MARKER_PATTERN = /(?:video|youtube)(\w+)/;
+const SCROLLPLAY_PCT_PATTERN = /scrollplay(\d+)/;
 
 const SELECTORS = {
   GLOBAL_NAV: '#abcHeader.global',
@@ -125,6 +127,8 @@ module.exports = {
   SM_RATIO_PATTERN,
   MD_RATIO_PATTERN,
   LG_RATIO_PATTERN,
+  VIDEO_MARKER_PATTERN,
+  SCROLLPLAY_PCT_PATTERN,
   SELECTORS,
   RICHTEXT_BLOCK_TAGNAMES,
   EMBED_TAGNAMES,


### PR DESCRIPTION
This set of changes enables a couple of features…

**First**, it enables a new `#video` marker, which works the same way as the `#youtube` marker, e.g.:

```
#video9400772
```

Put ^^^that^^^ anywhere in your story, and it will be transformed into a VideoEmbed (missing a Caption). This also supports preceding `#config` options, just like standard video embeds.

If you put it as the first child of a Header or Block, it will load an ambient VideoPlayer to use as the background media.

**Second**, it adds a new config option to Header and Block, called `supplant`. It allows you to use different media for different platforms, e.g. an image in environments that don't support Odyssey and a video (defined by a `#video` marker) for those that do.

This stops any environment showing both the image and video, and we no longer have native video players in the ABC App / Apple News for ambient videos that only make sense in environments that support Odyssey.

This option will even work for Headers that use the article's lead image (defined in the Core article's media field). In this case you'd just mark up your Header like this:

```
#headersupplant
#video9400772
This is the story's subtitle
#endheader
```

...then the video would only appear in the Odyssey; other (non-JS) platforms will get the media field's image.

The implementation of this feature is very simple. If you add the `supplant` option to `#header` or `#block`, we just discard the first element in the section before we try to set the background media. If you come up with a better way to do this plays nicely with the current media candidate selection code, I'm all for making this a bit smarter!

**NOTE**: Ensure any videos you plan to use in `#video` markers are published before your article goes live (unreferenced videos won't be caught in Core's publication cascade). Also, updates to the video documents won't trigger re-publication of the article either, so in this rare situation, please remember to manually re-publish your articles.