### PR TITLE
Added 'contain' option to Picture, VideoPlayer and YouTubePlayer

### DIFF
--- a/src/app/components/Block/index.js
+++ b/src/app/components/Block/index.js
@@ -16,6 +16,7 @@ require('./index.scss');
 
 function Block({
   type = 'richtext',
+  isContained,
   isDocked,
   isPiecemeal,
   isLight,
@@ -58,6 +59,7 @@ function Block({
     mediaEl = Picture({
       src,
       alt,
+      isContained,
       ratios
     });
   } else if (videoId) {
@@ -65,6 +67,7 @@ function Block({
       mediaEl = YouTubePlayer({
         videoId,
         isAmbient: true,
+        isContained,
         ratios
       });
     } else {
@@ -77,7 +80,8 @@ function Block({
         const replacementMediaEl = VideoPlayer(
           Object.assign(metadata, {
             ratios,
-            isAmbient: true
+            isAmbient: true,
+            isContained: isContained
           })
         );
 
@@ -141,6 +145,7 @@ function Block({
 }
 
 function transformSection(section) {
+  const isContained = section.configSC.indexOf('contain') > -1;
   const isDocked = section.configSC.indexOf('docked') > -1;
   const isPiecemeal = section.configSC.indexOf('piecemeal') > -1;
   const isLight = section.configSC.indexOf('light') > -1;
@@ -196,6 +201,7 @@ function transformSection(section) {
       return config;
     },
     {
+      isContained,
       isDocked,
       isPiecemeal,
       isLight,

--- a/src/app/components/Picture/index.js
+++ b/src/app/components/Picture/index.js
@@ -30,7 +30,14 @@ const IMAGE_LOAD_RANGE = 1;
 
 const pictures = [];
 
-function Picture({ src = SMALLEST_IMAGE, alt = '', ratios = {}, preserveOriginalRatio = false, linkUrl = '' }) {
+function Picture({
+  src = SMALLEST_IMAGE,
+  alt = '',
+  isContained = false,
+  ratios = {},
+  preserveOriginalRatio = false,
+  linkUrl = ''
+}) {
   const [, originalRatio] = src.match(RATIO_PATTERN) || [, null];
 
   ratios =
@@ -74,7 +81,7 @@ function Picture({ src = SMALLEST_IMAGE, alt = '', ratios = {}, preserveOriginal
   `;
 
   const pictureEl = html`
-    <a class="Picture">
+    <a class="Picture${isContained ? ' is-contained' : ''}">
       ${placeholderEl}
       ${picturePictureEl}
     </a>
@@ -176,6 +183,8 @@ subscribe(function _checkIfPicturesNeedToBeLoaded(client) {
 });
 
 module.exports = Picture;
+
+module.exports.PLACEHOLDER_PROPERTY = PLACEHOLDER_PROPERTY;
 
 module.exports.resize = ({ url = '', ratio = '16x9', size = 'md' }) =>
   url

--- a/src/app/components/Picture/index.scss
+++ b/src/app/components/Picture/index.scss
@@ -28,6 +28,10 @@
     will-change: opacity;
   }
 
+  &.is-contained img {
+    object-fit: contain;
+  }
+
   &[loaded] img {
     opacity: 1;
     animation: fadeIn 0.5s;

--- a/src/app/components/VideoPlayer/index.scss
+++ b/src/app/components/VideoPlayer/index.scss
@@ -28,21 +28,6 @@
     vertical-align: top;
     object-fit: cover;
 
-    // Until IE/Edge supports object-fit, ambient (control-less) video elements need
-    // to be resized, transformed and (effectively) clipped to cover their parents
-    _:-ms-lang(x),
-    &:not([controls]) {
-      transform: translate(-50%, -50%);
-      top: 50%;
-      left: 50%;
-      z-index: 0;
-      width: auto;
-      height: auto;
-      min-width: 100%;
-      min-height: 100%;
-      max-width: none;
-    }
-
     &:-webkit-full-screen {
       background-image: none !important;
       object-fit: contain;
@@ -68,6 +53,31 @@
       opacity: 0;
       width: 0.3125rem;
       pointer-events: none;
+    }
+  }
+
+  // Until IE/Edge supports object-fit, un-constrained ambient
+  // (control-less) video elements need to be resized, transformed
+  // and (effectively) clipped to cover their parents
+  _:-ms-lang(x),
+  &:not(.is-contained) video:not([controls]) {
+    transform: translate(-50%, -50%);
+    top: 50%;
+    left: 50%;
+    z-index: 0;
+    width: auto;
+    height: auto;
+    min-width: 100%;
+    min-height: 100%;
+    max-width: none;
+  }
+
+  &.is-contained video {
+    background-size: contain;
+    object-fit: contain;
+
+    &:not([paused]) {
+      background-image: none !important;
     }
   }
 }

--- a/src/app/components/YouTubePlayer/index.scss
+++ b/src/app/components/YouTubePlayer/index.scss
@@ -10,16 +10,21 @@
   }
 
   iframe {
-    transform: translate(-50%, -50%);
     position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+  }
+
+  &:not(.is-contained) iframe {
+    transform: translate(-50%, -50%);
     top: 50%;
     left: 50%;
-    width: 100%;
     min-width: 100%;
     max-width: none !important;
     min-height: 100%;
-    height: 100%;
-    pointer-events: none;
   }
 
   .VideoControls {
@@ -33,5 +38,9 @@
     width: 100%;
     height: 100%;
     object-fit: cover;
+  }
+
+  &.is-contained img {
+    object-fit: contain;
   }
 }

--- a/src/app/components/utilities/sizer.scss
+++ b/src/app/components/utilities/sizer.scss
@@ -7,12 +7,17 @@
   display: block;
   overflow: hidden;
   position: relative;
+  z-index: -1;
   min-height: 100%;
   background-image: var(--placeholder-image);
   background-position: center;
   background-repeat: no-repeat;
   background-size: 100%;
   background-size: cover;
+
+  .is-contained > & {
+    opacity: 0.5;
+  }
 
   .Picture & {
     background-color: $color-grey-500-transparent-65;


### PR DESCRIPTION
...which is currently able to be passed through Block config strings.

This keeps the media within its parent's constraints. Outside the letter/pillar-box, a dimmed blurred image appears (either the original image placeholder, or the video thumbnail).