### PR TITLE
Added new 'floating' variant to Header for seamless integration with following Block content/media.

### DIFF
--- a/src/app/components/Block/index.scss
+++ b/src/app/components/Block/index.scss
@@ -170,6 +170,18 @@
   .is-richtext:not(.is-piecemeal) > &:last-child {
     padding-top: 5rem;
     padding-bottom: 5rem;
+
+    .Header.is-floating + & {
+      margin-top: calc(140vh - #{$abc-nav-height + $size-bar});
+      margin-bottom: calc(40vh);
+      padding-top: 1.5rem;
+      padding-bottom: 1.5rem;
+
+      @media #{$mq-lg} {
+        padding-top: 2.25rem;
+        padding-bottom: 2.25rem;
+      }
+    }
   }
 
   .is-piecemeal > & {
@@ -185,6 +197,10 @@
 
     &:nth-child(2) {
       margin-top: 100vh;
+
+      .Header.is-floating + & {
+        margin-top: calc(180vh - #{$abc-nav-height + $size-bar});
+      }
     }
 
     &:last-child {

--- a/src/app/components/Header/index.js
+++ b/src/app/components/Header/index.js
@@ -25,16 +25,21 @@ function Header({
   interactiveEl,
   ratios = {},
   isDark,
+  isFloating,
   isLayered,
-  isNoMedia,
   isKicker,
   miscContentEls = []
 }) {
+  isFloating = isFloating || (isLayered && !imgEl && !videoElOrId && !interactiveEl);
+  isLayered = isLayered || isFloating;
+  isDark = meta.isDarkMode || isLayered || isDark;
+
   const className = cn(
     'Header',
     {
-      'is-dark': meta.isDarkMode || isDark,
-      'is-layered': isLayered && (imgEl || videoElOrId || interactiveEl)
+      'is-dark': isDark,
+      'is-floating': isFloating,
+      'is-layered': isLayered
     },
     'u-full'
   );
@@ -96,6 +101,7 @@ function Header({
   } else if (interactiveEl) {
     mediaEl = interactiveEl.cloneNode(true);
     mediaEl.classList.add('Header-interactive');
+  } else {
   }
 
   const clonedMiscContentEls = miscContentEls.map(el => {
@@ -157,7 +163,7 @@ function Header({
     ]);
 
   const headerContentEl = html`
-    <div class="Header-content u-richtext${isDark || (isLayered && mediaEl) ? '-invert' : ''}">
+    <div class="Header-content u-richtext${isDark ? '-invert' : ''}">
       ${contentEls}
     </div>
   `;
@@ -203,9 +209,10 @@ function Header({
 
 function transformSection(section, meta) {
   const ratios = getRatios(section.configSC);
-  const isDark = section.configSC.indexOf('dark') > -1;
-  const isLayered = section.configSC.indexOf('layered') > -1;
-  const isNoMedia = section.configSC.indexOf('nomedia') > -1;
+  const isFloating = section.configSC.indexOf('floating') > -1;
+  const isLayered = isFloating || section.configSC.indexOf('layered') > -1;
+  const isDark = isLayered || section.configSC.indexOf('dark') > -1;
+  const isNoMedia = isFloating || section.configSC.indexOf('nomedia') > -1;
   const isKicker = section.configSC.indexOf('kicker') > -1;
   const shouldSupplant = section.configSC.indexOf('supplant') > -1;
 
@@ -285,8 +292,8 @@ function transformSection(section, meta) {
       meta,
       ratios,
       isDark,
+      isFloating,
       isLayered,
-      isNoMedia,
       isKicker,
       miscContentEls: []
     }

--- a/src/app/components/Header/index.js
+++ b/src/app/components/Header/index.js
@@ -101,7 +101,6 @@ function Header({
   } else if (interactiveEl) {
     mediaEl = interactiveEl.cloneNode(true);
     mediaEl.classList.add('Header-interactive');
-  } else {
   }
 
   const clonedMiscContentEls = miscContentEls.map(el => {

--- a/src/app/components/Header/index.scss
+++ b/src/app/components/Header/index.scss
@@ -9,12 +9,11 @@
     font-size: 1.25rem;
   }
 
-  &.is-dark,
-  &.is-layered {
+  &.is-dark {
     background-color: $color-black;
   }
 
-  .is-dark-mode &:not(.is-dark):not(.is-layered) {
+  .is-dark-mode &:not(.is-dark) {
     background-color: $color-grey-50;
   }
 
@@ -23,6 +22,11 @@
     flex-direction: column;
     justify-content: flex-end;
     min-height: calc(100vh - #{$abc-nav-height + $size-bar});
+  }
+
+  &.is-floating {
+    margin-bottom: calc(-100vh + #{$abc-nav-height + $size-bar}) !important;
+    background-color: transparent;
   }
 }
 
@@ -48,6 +52,10 @@
     > * {
       height: 100%;
     }
+  }
+
+  .is-floating > & {
+    display: none;
   }
 
   .Header-interactive > div > div {
@@ -94,6 +102,10 @@
     @media #{$mq-lg} {
       margin-top: 28rem;
     }
+  }
+
+  .is-floating > & {
+    z-index: 1;
   }
 }
 
@@ -250,7 +262,6 @@
   font-size: 0.75rem;
   color: $color-grey-500;
 
-  .is-layered &,
   .is-dark & {
     color: $color-grey-300;
   }

--- a/src/app/components/Header/index.scss
+++ b/src/app/components/Header/index.scss
@@ -92,16 +92,8 @@
   }
 
   .is-layered > & {
-    margin-top: 16rem;
+    margin-top: auto;
     background-image: $gradient-vertical-0-45-100-75;
-
-    @media #{$mq-md} {
-      margin-top: 22rem;
-    }
-
-    @media #{$mq-lg} {
-      margin-top: 28rem;
-    }
   }
 
   .is-floating > & {


### PR DESCRIPTION
This new header variant looks the same as a layered Header, but has no media of its own. Instead, it negates its own physical space with negative margin, so the next component that follows it, sits beneath.

The rationale for this is our need to have a Header content that blends seamlessly with a Block / Scrollyteller, and leveraging the Block's media seemed the cleanest way to pull it off.

I also tidied up the hierarchy of variant effects in Headers, so that all floating headers enforce the layered appearance, and as a result, all layered variants enforce the dark appearance (white text on black). Floating headers are also strict about not using media, so they behave as if you applied the nomedia variant to the Header.

Blocks have also been modified so that they create additional empty space at the beginning of their content, so they never collide with the Header content.

Note: This effect should work really well with the Scrollyteller plugin, but we may have to make a small edit to it so that it behaves the same way Blocks do with regard to leading space.