### PR TITLE
Bg color light mode fix

### DIFF
--- a/src/app/components/Header/index.scss
+++ b/src/app/components/Header/index.scss
@@ -4,6 +4,7 @@
   overflow: hidden;
   position: relative;
   line-height: 1.5;
+  background-color: $color-grey-50;
 
   @media #{$mq-not-sm} {
     font-size: 1.25rem;

--- a/src/app/reset/index.scss
+++ b/src/app/reset/index.scss
@@ -30,45 +30,45 @@ body {
   background-color: $color-grey-50;
   background-color: var(--bg, #{$color-grey-50});
 
-  .is-dark-mode > & {
-    background-color: $color-black;
-    background-color: var(--bg, #{$color-black});
+  // .is-dark-mode > & {
+  //   background-color: $color-black;
+  //   background-color: var(--bg, #{$color-black});
 
-    main + .page_margins ::before,
-    main + .page_margins ::after,
-    main + .content ::before,
-    main + .content ::after {
-      content: '';
-      position: absolute;
-      background-color: inherit;
-    }
+  //   main + .page_margins ::before,
+  //   main + .page_margins ::after,
+  //   main + .content ::before,
+  //   main + .content ::after {
+  //     content: '';
+  //     position: absolute;
+  //     background-color: inherit;
+  //   }
 
-    main + .page_margins,
-    main + .content {
-      position: relative;
+  //   main + .page_margins,
+  //   main + .content {
+  //     position: relative;
 
-      &::before,
-      &::after {
-        content: '';
-        position: absolute;
-        top: 0;
-        width: 50vw;
-        height: 100%;
-        background-color: inherit;
-      }
+  //     &::before,
+  //     &::after {
+  //       content: '';
+  //       position: absolute;
+  //       top: 0;
+  //       width: 50vw;
+  //       height: 100%;
+  //       background-color: inherit;
+  //     }
 
-      &::before {
-        left: -50vw;
-      }
+  //     &::before {
+  //       left: -50vw;
+  //     }
 
-      &::after {
-        right: -50vw;
-      }
+  //     &::after {
+  //       right: -50vw;
+  //     }
 
-      & > * {
-        border-top: 0;
-      }
-    }
+  //     & > * {
+  //       border-top: 0;
+  //     }
+  //   }
 
     main + .page_margins {
       background-color: $color-grey-50;
@@ -77,6 +77,53 @@ body {
     main + .content {
       background-color: $color-white;
     }
+  }
+
+  background-color: $color-black;
+  background-color: var(--bg, #{$color-black});
+
+  main + .page_margins ::before,
+  main + .page_margins ::after,
+  main + .content ::before,
+  main + .content ::after {
+    content: '';
+    position: absolute;
+    background-color: inherit;
+  }
+
+  main + .page_margins,
+  main + .content {
+    position: relative;
+
+    &::before,
+    &::after {
+      content: '';
+      position: absolute;
+      top: 0;
+      width: 50vw;
+      height: 100%;
+      background-color: inherit;
+    }
+
+    &::before {
+      left: -50vw;
+    }
+
+    &::after {
+      right: -50vw;
+    }
+
+    & > * {
+      border-top: 0;
+    }
+  }
+
+  main + .page_margins {
+    background-color: $color-grey-50;
+  }
+
+  main + .content {
+    background-color: $color-white;
   }
 }
 

--- a/src/app/reset/index.scss
+++ b/src/app/reset/index.scss
@@ -30,57 +30,10 @@ body {
   background-color: $color-grey-50;
   background-color: var(--bg, #{$color-grey-50});
 
-  // .is-dark-mode > & {
-  //   background-color: $color-black;
-  //   background-color: var(--bg, #{$color-black});
-
-  //   main + .page_margins ::before,
-  //   main + .page_margins ::after,
-  //   main + .content ::before,
-  //   main + .content ::after {
-  //     content: '';
-  //     position: absolute;
-  //     background-color: inherit;
-  //   }
-
-  //   main + .page_margins,
-  //   main + .content {
-  //     position: relative;
-
-  //     &::before,
-  //     &::after {
-  //       content: '';
-  //       position: absolute;
-  //       top: 0;
-  //       width: 50vw;
-  //       height: 100%;
-  //       background-color: inherit;
-  //     }
-
-  //     &::before {
-  //       left: -50vw;
-  //     }
-
-  //     &::after {
-  //       right: -50vw;
-  //     }
-
-  //     & > * {
-  //       border-top: 0;
-  //     }
-  //   }
-
-    main + .page_margins {
-      background-color: $color-grey-50;
-    }
-
-    main + .content {
-      background-color: $color-white;
-    }
+  .is-dark-mode > & {
+    background-color: $color-black;
+    background-color: var(--bg, #{$color-black});
   }
-
-  background-color: $color-black;
-  background-color: var(--bg, #{$color-black});
 
   main + .page_margins ::before,
   main + .page_margins ::after,


### PR DESCRIPTION
On light-mode (normal mode) when you specify a background colour using --bg:#473947 the colour spills up behind the header and also below the article.

This fixes it so behaviour is consistent with when you set a background colour in dark mode ie. the header will be dark and the content background will be --bg:#473947 and below the article will be light as normal.

This doesn't completely address all of #34 but @colingourlay and I reckon we can close it now.