### PR TITLE
Odyssey loading can be overridden with query param

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -78,6 +78,15 @@ const SMALLEST_IMAGE = 'data:image/gif;base64,R0lGODlhAQABAAAAADs=';
 
 const IS_PREVIEW = window.location.hostname.indexOf('nucwed') > -1;
 
+const QUERY = {};
+window.location.search
+  .replace(/\?/, '')
+  .split('&')
+  .forEach(q => {
+    q = q.split('=');
+    QUERY[q[0]] = q[1];
+  });
+
 const MS_VERSION = (ua => {
   const msie = ua.indexOf('MSIE ');
 
@@ -138,6 +147,7 @@ module.exports = {
   MQ,
   SMALLEST_IMAGE,
   IS_PREVIEW,
+  QUERY,
   MS_VERSION,
   IS_IOS,
   SUPPORTS_PASSIVE

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,30 @@
-// Polyfills
-require('./polyfills');
-require('objectFitPolyfill');
+const { IS_PREVIEW, QUERY } = require('./constants');
 
-// Global styles
-require('./fonts.scss');
-require('./keyframes.scss');
-require('./app/components/utilities/index.scss');
+let shouldLoadNow = true;
 
-// App
-require('./app')();
+if (IS_PREVIEW && QUERY['odyssey']) {
+  const odyssey = QUERY['odyssey'].split('-');
+  const scriptUrl = `//${odyssey[0]}.aus.aunty.abc.net.au:${odyssey[1] || 8000}/index.js`;
+
+  if (!document.querySelector(`script[src="${scriptUrl}"]`)) {
+    shouldLoadNow = false;
+
+    const script = document.createElement('script');
+    script.src = scriptUrl;
+    document.querySelector('head').appendChild(script);
+  }
+}
+
+if (shouldLoadNow) {
+  // Polyfills
+  require('./polyfills');
+  require('objectFitPolyfill');
+
+  // Global styles
+  require('./fonts.scss');
+  require('./keyframes.scss');
+  require('./app/components/utilities/index.scss');
+
+  // App
+  require('./app')();
+}


### PR DESCRIPTION
Specifying an article path with `?odyssey=ws205042` (where the value is your computer reference) will force Odyssey to load from your locally running version.

You can override the port by adding `-5000` or whatever number you need to the `odyssey` value. Eg. `?odyssey=ws205042-5000` will tell it to look on port 5000.