### PR TITLE
Recirculation Cards

### DIFF
--- a/src/app/components/Block/index.scss
+++ b/src/app/components/Block/index.scss
@@ -486,8 +486,8 @@
 
   .is-richtext > & [class*='u-pull'] {
     float: none;
-    margin-left: auto;
-    margin-right: auto;
+    margin-left: auto !important;
+    margin-right: auto !important;
     width: cells(10);
 
     @media #{$mq-lg} {

--- a/src/app/components/Recirculation/index.js
+++ b/src/app/components/Recirculation/index.js
@@ -1,0 +1,87 @@
+// External
+const html = require('bel');
+
+// Ours
+const { invalidateClient } = require('../../scheduler');
+const { getDocument } = require('../../utils/capi');
+const Picture = require('../Picture');
+require('./index.scss');
+
+const PICTURE_RATIOS = {
+  sm: '16x9',
+  md: '16x9',
+  lg: '16x9'
+};
+
+function Recirculation({ ids, pull }) {
+  const itemEls = ids.map(id => html`<a class="Recirculation-item" href="/news/${id}"></a>`);
+
+  const el = html`
+  <aside class="Recirculation${pull ? ` u-pull-${pull}` : ''}" role="complementary">
+    ${itemEls}
+  </aside>
+`;
+
+  el.classList.add('has-children');
+  ids.forEach((id, index) =>
+    getDocument(id, (err, item) => {
+      if (err) {
+        itemEl.classList.add('is-missing');
+
+        return console.error(err);
+      }
+
+      const itemEl = itemEls[index];
+      const title = item.shortTeaserTitle || item.teaserTitle || item.title;
+      const teaserText = item.shortTeaserTextPlain || item.teaserTextPlain;
+
+      itemEl.appendChild(html`<h2>${title}</h2>`);
+
+      if (item.thumbnailLink) {
+        itemEl.appendChild(Picture({ src: item.thumbnailLink.media[0].url, ratios: PICTURE_RATIOS }));
+        invalidateClient();
+      }
+
+      if (item.textPlain.indexOf(teaserText) !== 0) {
+        itemEl.appendChild(html`<p>${teaserText}</p>`);
+      }
+
+      itemEl.appendChild(html`<div>Read more →</div>`);
+
+      el.classList.add('has-children');
+    })
+  );
+
+  return el;
+}
+
+const DIGITS_PATTERN = /\d+/;
+const PULL_PATTERN = /[a-z]+/;
+let nextRelatedStoriesIdsIndex = 0;
+
+function transformMarker(marker, meta) {
+  const [digits] = marker.configSC.match(DIGITS_PATTERN) || [1];
+  const [pull] = marker.configSC.match(PULL_PATTERN) || ['right'];
+  let ids;
+
+  switch (marker.name) {
+    case 'tease':
+      if (digits !== 1) {
+        ids = [digits];
+      }
+      break;
+    case 'related':
+      ids = meta.relatedStoriesIds.slice(nextRelatedStoriesIdsIndex, +digits + nextRelatedStoriesIdsIndex);
+      nextRelatedStoriesIdsIndex += ids.length;
+      break;
+    default:
+      break;
+  }
+
+  if (ids && ids.length) {
+    marker.substituteWith(Recirculation({ ids, pull }));
+  }
+}
+
+module.exports = Recirculation;
+module.exports.transformMarker = transformMarker;

--- a/src/app/components/Recirculation/index.scss
+++ b/src/app/components/Recirculation/index.scss
@@ -1,0 +1,83 @@
+@import '../../../constants';
+
+.Recirculation:not(.has-children) {
+  display: none;
+}
+
+.Recirculation-item {
+  display: block;
+  border: 0.0625rem solid $color-grey-300-transparent-70;
+  padding: 1rem 1.1875rem;
+  font-size: 0.875rem;
+  transition: opacity 0.5s;
+
+  &.is-missing {
+    display: none;
+  }
+
+  &:empty {
+    opacity: 0.25;
+    color: $color-grey-300-transparent-70 !important;
+
+    &::before,
+    &::after {
+      display: block;
+      letter-spacing: -1px;
+    }
+
+    &::before {
+      content: '▇▇▇▇▇ ▇▇▇ ▇▇▇▇';
+      padding-bottom: calc(1.25rem + 56.25%);
+      font-size: 1.125rem;
+    }
+
+    &::after {
+      content: '▇▇▇▇▇ ▇▇▇▇▇▇▇ ▇▇▇▇ ▇▇▇ ▇▇▇▇▇▇▇ ▇▇▇▇ ▇▇▇ ▇▇▇▇▇▇ ▇▇▇▇▇ ▇▇▇ ▇▇▇▇▇';
+      padding-bottom: 2rem;
+      font-size: 0.8125rem;
+    }
+  }
+
+  &:hover,
+  &:active {
+    text-decoration: none !important;
+  }
+
+  & > * {
+    margin: 0;
+    font-family: $font-sans;
+  }
+
+  & > :not(:first-child) {
+    margin-top: 0.75rem;
+  }
+
+  & > h2 {
+    font-size: 1.125rem;
+    line-height: 1.294117647;
+    text-transform: none;
+  }
+
+  & > img {
+    width: 100%;
+    vertical-align: bottom;
+  }
+
+  & > p {
+    color: $color-black !important;
+    font-size: 0.8125rem;
+    line-height: 1.555555556;
+  }
+
+  .u-richtext-invert > .Recirculation > & > p {
+    color: $color-white !important;
+  }
+}
+
+.Recirculation-item:not(.is-missing) ~ .Recirculation-item:not(.is-missing) {
+  margin-top: 1.5rem;
+
+  @media #{$mq-lg} {
+    margin-top: 2.25rem;
+  }
+}

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -13,6 +13,7 @@ const ImageEmbed = require('./components/ImageEmbed');
 const MasterGallery = require('./components/MasterGallery');
 const Nav = require('./components/Nav');
 const Quote = require('./components/Quote');
+const Recirculation = require('./components/Recirculation');
 const ScrollHint = require('./components/ScrollHint');
 const Series = require('./components/Series');
 const Share = require('./components/Share');
@@ -21,7 +22,7 @@ const UQuote = require('./components/UQuote');
 const UParallax = require('./components/UParallax');
 const UPull = require('./components/UPull');
 const VideoEmbed = require('./components/VideoEmbed');
-const { enqueue, start, subscribe } = require('./scheduler');
+const { start } = require('./scheduler');
 const { getMeta } = require('./meta');
 const { prepare, reset } = require('./reset');
 const { getMarkers, getSections } = require('./utils/anchors');
@@ -90,7 +91,7 @@ function app() {
     .forEach(UQuote.conditionallyApply);
 
   // Transform markers
-  getMarkers(['cta', 'hr', 'scrollhint', 'series', 'share', 'video', 'youtube']).forEach(marker => {
+  getMarkers(['cta', 'hr', 'scrollhint', 'series', 'share', 'video', 'youtube', 'related', 'tease']).forEach(marker => {
     let el;
 
     switch (marker.name) {
@@ -115,6 +116,10 @@ function app() {
       case 'video':
       case 'youtube':
         VideoEmbed.transformMarker(marker);
+        break;
+      case 'related':
+      case 'tease':
+        Recirculation.transformMarker(marker, meta);
         break;
       default:
         break;

--- a/src/app/meta/index.js
+++ b/src/app/meta/index.js
@@ -1,13 +1,12 @@
 // External
-const html = require('bel');
 const { parseDate } = require('inn-abcdatetime-lib');
+const url2cmid = require('util-url2cmid');
 
 // Ours
 const { MOCK_ELEMENT, SELECTORS } = require('../../constants');
 const { $, $$, detach } = require('../utils/dom');
 const { trim } = require('../utils/misc');
 
-const EMPHASISABLE_BYLINE_TEXT_PATTERN = /^(?:by|,|and)$/;
 const STARTS_WITH_YEAR_PATTERN = /^\d{4}-/;
 const ROGUE_YEAR_COLON_PATTERN = /:(\d+)$/;
 
@@ -114,6 +113,13 @@ function getShareLinks() {
     .sort((a, b) => SHARE_ORDERING.indexOf(a.id) - SHARE_ORDERING.indexOf(b.id));
 }
 
+function getRelatedStoriesIds() {
+  return $$(`
+    .attached-content > .inline-content.story > a,
+    .related > article > a
+  `).map(el => url2cmid(el.href));
+}
+
 function getRelatedMedia() {
   const relatedMediaEl = $(`
     .view-hero-media,
@@ -139,6 +145,7 @@ function getMeta() {
       infoSource: getInfoSource(),
       shareLinks: getShareLinks(),
       relatedMedia: getRelatedMedia(),
+      relatedStoriesIds: getRelatedStoriesIds(),
       theme: getMetaContent('theme'),
       hasCaptionAttributions: getMetaContent('caption-attributions') !== 'false',
       hasCommentsEnabled: getMetaContent('showLivefyreComments') === 'true',

--- a/src/app/reset/index.js
+++ b/src/app/reset/index.js
@@ -29,7 +29,7 @@ const TEMPLATE_REMOVABLES = {
     header > .section
     .content > article
     .share
-    .related
+    .related:not(.m-recirc)
   `),
   '.platform-standard.platform-mobile': literalList(`
     #page-header

--- a/src/app/reset/index.scss
+++ b/src/app/reset/index.scss
@@ -76,7 +76,7 @@ body {
   }
 
   main + .content {
-    background-color: $color-white;
+    background-color: #f1f1f1;
   }
 }
 

--- a/src/app/utils/capi.js
+++ b/src/app/utils/capi.js
@@ -1,0 +1,27 @@
+// External
+const xhr = require('xhr');
+
+const ENDPOINT =
+  window.location.hostname.indexOf('nucwed') === -1 || window.location.search.indexOf('prod') > -1
+    ? 'https://content-gateway.abc-prod.net.au'
+    : 'http://nucwed.aus.aunty.abc.net.au';
+
+module.exports.getDocument = (cmid, done) => {
+  if (!cmid.length && cmid != +cmid) {
+    return done(new Error(`Invalid CMID: ${cmid}`));
+  }
+
+  xhr(
+    {
+      responseType: 'json',
+      uri: `${ENDPOINT}/api/v2/content/id/${cmid}`
+    },
+    (error, response, content) => {
+      if (error || response.statusCode !== 200) {
+        return done(error || new Error(response.statusCode));
+      }
+
+      done(null, typeof content === 'object' ? content : JSON.parse(content));
+    }
+  );
+};


### PR DESCRIPTION
A recirculation card is similar to a Teaser (Viewtype: WYSIWYG) that we’d currently manually create and embed in our standard article template. They have a title, plus an image and teaser text if they’re available.

The below example was created by adding at least one story to Related, then inserting a #related tag where you want it to appear.

![Example Recirculation Card](https://user-images.githubusercontent.com/66612/45523661-d60c0e00-b80d-11e8-95b0-657123f58f8b.png)

* The title displayed is first available of: **Short Teaser Title** > **Teaser Title** > **Title**.
* The image displayed is the first available of: **Thumbnail Image** > **Media** (Image) > (none).
* The teaser text displayed is the first available of: **Short Teaser Text** > **Teaser Text** > (none).

Because recirculation cards are all tag-based, they won’t appear in syndicated content. Related stories will appear together (at the bottom) off-platform like they usually would.

I feel like these would be used _very_ sparingly. They address the issue of lower recirculation on Odyssey stories (due to us losing the sidebar on desktop), but introduce the possibility for people to bounce out of our stories without finishing them. I kinda feel, however, that if someone's gonna leave the story early, we'd rather they found something more relevant to them on our network then leaving the site entirely. Maybe I'm wrong 🤷‍♂️.

This PR also includes a fix for the mobile site where we were deleting the Top Stories module at the bottom of the page (by treating it the same as Related, which we mean to delete).