### PR TITLE
Remove iphone-inline-video polyfill (for iOS8/9).

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6939,11 +6939,6 @@
       "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
       "dev": true
     },
-    "intervalometer": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/intervalometer/-/intervalometer-1.0.4.tgz",
-      "integrity": "sha1-6AcimuisLL+RVswBDusge25lrSM="
-    },
     "invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
@@ -6976,15 +6971,6 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
       "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4=",
       "dev": true
-    },
-    "iphone-inline-video": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/iphone-inline-video/-/iphone-inline-video-2.0.2.tgz",
-      "integrity": "sha1-fnId8HyJG0C2CJnFw0pPVC0zLxE=",
-      "requires": {
-        "intervalometer": "^1.0.0",
-        "poor-mans-symbol": "^1.0.1"
-      }
     },
     "is-absolute-url": {
       "version": "2.1.0",
@@ -9883,11 +9869,6 @@
       "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
       "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
       "dev": true
-    },
-    "poor-mans-symbol": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/poor-mans-symbol/-/poor-mans-symbol-1.0.1.tgz",
-      "integrity": "sha1-DBtl/x1JwHQCsiNeViB30SBnHQw="
     },
     "portfinder": {
       "version": "1.0.17",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "custom-event-polyfill": "^1.0.6",
     "debounce": "^1.1.0",
     "inn-abcdatetime-lib": "git+ssh://git@stash.abc-dev.net.au:7999/news/news-abcdatetime-lib#v1.1.3",
-    "iphone-inline-video": "^2.0.2",
     "load-script": "^1.0.0",
     "objectFitPolyfill": "^2.0.4",
     "picturefill": "^3.0.2",

--- a/src/app/components/VideoPlayer/index.js
+++ b/src/app/components/VideoPlayer/index.js
@@ -1,6 +1,5 @@
 // External
 const html = require('bel');
-const playInline = require('iphone-inline-video').default;
 const raf = require('raf');
 
 // Ours
@@ -102,13 +101,6 @@ function VideoPlayer({
 
   if (source) {
     videoEl.src = source.src;
-  }
-
-  // iOS8-9 inline video (muted only)
-  if (IS_IOS) {
-    raf(() => {
-      playInline(videoEl, !isMuted);
-    });
   }
 
   let fuzzyCurrentTime = 0;


### PR DESCRIPTION
The percentage of the audience using iOS 8 or 9 on an iPhone (iPads don't need this polyfill) is close to 0%.