### PR TITLE
Until the Presentation Layer masthead is consistent across all phases…

### DIFF
--- a/src/app/reset/index.scss
+++ b/src/app/reset/index.scss
@@ -80,6 +80,13 @@ body {
   }
 }
 
+/* Until the Presentation Layer masthead is consistent across all phases, retain the classic ABC global header */
+
 #abcHeader.global {
+  display: block !important;
   max-width: inherit;
+}
+
+.masthead-container {
+  display: none !important;
 }


### PR DESCRIPTION
…retain the classic ABC global header