### PR TITLE
Self-loading VideoPlayer component

### DIFF
--- a/src/app/components/Block/index.js
+++ b/src/app/components/Block/index.js
@@ -4,11 +4,10 @@ const html = require('bel');
 const url2cmid = require('util-url2cmid');
 
 // Ours
-const { ALIGNMENT_PATTERN, VIDEO_MARKER_PATTERN, IS_PREVIEW } = require('../../../constants');
-const { enqueue, invalidateClient, subscribe } = require('../../scheduler');
-const { $, detach, isElement, substitute } = require('../../utils/dom');
+const { ALIGNMENT_PATTERN, VIDEO_MARKER_PATTERN } = require('../../../constants');
+const { enqueue, subscribe } = require('../../scheduler');
+const { $, detach, isElement } = require('../../utils/dom');
 const { getRatios, trim } = require('../../utils/misc');
-const Caption = require('../Caption');
 const Picture = require('../Picture');
 const VideoPlayer = require('../VideoPlayer');
 const YouTubePlayer = require('../YouTubePlayer');
@@ -93,37 +92,11 @@ function Block({
             ratios
           });
         } else {
-          backgroundEl = html`<div></div>`;
-          VideoPlayer.getMetadata(element.videoId, (err, metadata) => {
-            if (err) {
-              return;
-            }
-
-            const replacementMediaEl = VideoPlayer(
-              Object.assign(metadata, {
-                ratios,
-                isContained,
-                isInvariablyAmbient: true
-              })
-            );
-
-            // Reapply the classes that handle transitions
-            replacementMediaEl.classList.add('background-transition');
-            if (TRANSITIONS.indexOf(transition) > -1) {
-              replacementMediaEl.classList.add(transition);
-            } else {
-              replacementMediaEl.classList.add('colour');
-            }
-
-            substitute(backgroundEl, replacementMediaEl);
-
-            // Make sure we swap in our new video element
-            backgrounds = backgrounds.map(b => {
-              if (b === backgroundEl) return replacementMediaEl;
-              return b;
-            });
-
-            invalidateClient();
+          backgroundEl = VideoPlayer({
+            videoElOrId: element.videoId,
+            ratios,
+            isContained,
+            isInvariablyAmbient: true
           });
         }
       }
@@ -157,22 +130,11 @@ function Block({
         ratios
       });
     } else {
-      mediaEl = html`<div></div>`;
-      VideoPlayer.getMetadata(videoId, (err, metadata) => {
-        if (err) {
-          return;
-        }
-
-        const replacementMediaEl = VideoPlayer(
-          Object.assign(metadata, {
-            ratios,
-            isContained: isContained,
-            isInvariablyAmbient: true
-          })
-        );
-
-        substitute(mediaEl, replacementMediaEl);
-        invalidateClient();
+      mediaEl = VideoPlayer({
+        videoElOrId: videoId,
+        ratios,
+        isContained: isContained,
+        isInvariablyAmbient: true
       });
     }
   }

--- a/src/app/components/Block/index.js
+++ b/src/app/components/Block/index.js
@@ -34,7 +34,6 @@ function Block({
   isLight,
   alignment,
   videoId,
-  isVideoMarker,
   isVideoYouTube,
   imgEl,
   ratios = {},
@@ -159,7 +158,7 @@ function Block({
       });
     } else {
       mediaEl = html`<div></div>`;
-      VideoPlayer[`getMetadata${isVideoMarker ? 'FromDetailPage' : ''}`](videoId, (err, metadata) => {
+      VideoPlayer.getMetadata(videoId, (err, metadata) => {
         if (err) {
           return;
         }
@@ -454,7 +453,6 @@ function transformSection(section) {
   } else {
     // Transitions are not being used so business as usual
     config = section.betweenNodes.reduce((_config, node) => {
-      let classList;
       let videoId;
       let imgEl;
 
@@ -462,7 +460,6 @@ function transformSection(section) {
         classList = node.className.split(' ');
 
         if (node.name && !!node.name.match(VIDEO_MARKER_PATTERN)) {
-          _config.isVideoMarker = true;
           _config.isVideoYouTube = node.name.split('youtube')[1];
           _config.videoElOrId = videoId = node.name.match(VIDEO_MARKER_PATTERN)[1];
         } else {

--- a/src/app/components/Block/index.js
+++ b/src/app/components/Block/index.js
@@ -87,13 +87,13 @@ function Block({
         if (element.isVideoYouTube) {
           backgroundEl = YouTubePlayer({
             videoId: element.videoId,
+            ratios,
             isAmbient: true,
-            isContained,
-            ratios
+            isContained
           });
         } else {
           backgroundEl = VideoPlayer({
-            videoElOrId: element.videoId,
+            videoId: element.videoId,
             ratios,
             isContained,
             isInvariablyAmbient: true
@@ -125,13 +125,13 @@ function Block({
     if (isVideoYouTube) {
       mediaEl = YouTubePlayer({
         videoId,
+        ratios,
         isAmbient: true,
-        isContained,
-        ratios
+        isContained
       });
     } else {
       mediaEl = VideoPlayer({
-        videoElOrId: videoId,
+        videoId,
         ratios,
         isContained: isContained,
         isInvariablyAmbient: true
@@ -345,9 +345,8 @@ function transformSection(section) {
         if (node.name && !!node.name.match(VIDEO_MARKER_PATTERN)) {
           videoMarker = {
             isVideoYouTube: node.name.split('youtube')[1],
-            videoElOrId: node.name.match(VIDEO_MARKER_PATTERN)[1]
+            videoId: node.name.match(VIDEO_MARKER_PATTERN)[1]
           };
-          videoMarker.videoId = videoMarker.videoElOrId;
         } else {
           videoMarker.videoId = detectVideoId(node);
         }
@@ -423,7 +422,7 @@ function transformSection(section) {
 
         if (node.name && !!node.name.match(VIDEO_MARKER_PATTERN)) {
           _config.isVideoYouTube = node.name.split('youtube')[1];
-          _config.videoElOrId = videoId = node.name.match(VIDEO_MARKER_PATTERN)[1];
+          _config.videoId = videoId = node.name.match(VIDEO_MARKER_PATTERN)[1];
         } else {
           videoId = detectVideoId(node);
         }

--- a/src/app/components/Gallery/index.js
+++ b/src/app/components/Gallery/index.js
@@ -467,7 +467,7 @@ function transformSection(section) {
 
       if (videoId) {
         const videoPlayerEl = VideoPlayer({
-          videoElOrId: videoId,
+          videoId,
           ratios: {
             sm: ratios.sm || '3x4',
             md: ratios.md,
@@ -477,7 +477,7 @@ function transformSection(section) {
         });
         const mosaidVideoPlayerEls = [
           VideoPlayer({
-            videoElOrId: videoId,
+            videoId,
             ratios: {
               sm: ratios.sm || '3x2',
               md: ratios.md || '16x9',
@@ -486,7 +486,7 @@ function transformSection(section) {
             isInvariablyAmbient: true
           }),
           VideoPlayer({
-            videoElOrId: videoId,
+            videoId,
             ratios: {
               sm: ratios.sm || '1x1',
               md: ratios.md,
@@ -495,7 +495,7 @@ function transformSection(section) {
             isInvariablyAmbient: true
           }),
           VideoPlayer({
-            videoElOrId: videoId,
+            videoId,
             ratios: {
               sm: ratios.sm || '3x4',
               md: ratios.md || '4x3',

--- a/src/app/components/Gallery/index.js
+++ b/src/app/components/Gallery/index.js
@@ -331,7 +331,7 @@ function Gallery({ items = [], masterCaptionEl, mosaicRowLengths = [] }) {
     `;
 
     if (mediaEl.hasAttribute('data-video-player-placeholder')) {
-      VideoPlayer.getMetadataFromDetailPage(id, (err, metadata) => {
+      VideoPlayer.getMetadata(id, (err, metadata) => {
         if (err) {
           return;
         }

--- a/src/app/components/Header/index.js
+++ b/src/app/components/Header/index.js
@@ -6,8 +6,8 @@ const url2cmid = require('util-url2cmid');
 
 // Ours
 const { MS_VERSION, VIDEO_MARKER_PATTERN } = require('../../../constants');
-const { enqueue, invalidateClient, subscribe } = require('../../scheduler');
-const { $, detach, isElement, substitute } = require('../../utils/dom');
+const { enqueue, subscribe } = require('../../scheduler');
+const { $, detach, isElement } = require('../../utils/dom');
 const { dePx, getRatios, slug, trim } = require('../../utils/misc');
 const ScrollHint = require('../ScrollHint');
 const Picture = require('../Picture');
@@ -62,46 +62,23 @@ function Header({
       alt: imgEl.getAttribute('alt'),
       ratios
     });
-
-    if (!isLayered) {
-      mediaEl.classList.add('u-parallax');
-    }
   } else if (videoElOrId) {
-    if (isVideoYouTube) {
-      mediaEl = YouTubePlayer({
-        videoId: videoElOrId,
-        isAmbient: true,
-        ratios
-      });
+    mediaEl = isVideoYouTube
+      ? YouTubePlayer({
+          videoId: videoElOrId,
+          isAmbient: true,
+          ratios
+        })
+      : VideoPlayer({
+          videoElOrId,
+          ratios,
+          isInvariablyAmbient: true
+        });
+  }
 
-      if (!isLayered) {
-        mediaEl.classList.add('u-parallax');
-        UParallax.activate(mediaEl);
-      }
-    } else {
-      mediaEl = html`<div></div>`;
-      VideoPlayer.getMetadata(videoElOrId, (err, metadata) => {
-        if (err) {
-          return;
-        }
-
-        const replacementMediaEl = VideoPlayer(
-          Object.assign(metadata, {
-            ratios,
-            isInvariablyAmbient: true
-          })
-        );
-
-        substitute(mediaEl, replacementMediaEl);
-
-        if (!isLayered) {
-          replacementMediaEl.classList.add('u-parallax');
-          UParallax.activate(replacementMediaEl);
-        }
-
-        invalidateClient();
-      });
-    }
+  if (mediaEl && !interactiveEl && !isLayered) {
+    mediaEl.classList.add('u-parallax');
+    UParallax.activate(mediaEl);
   }
 
   const clonedMiscContentEls = miscContentEls.map(el => {

--- a/src/app/components/Header/index.js
+++ b/src/app/components/Header/index.js
@@ -19,7 +19,6 @@ require('./index.scss');
 function Header({
   meta = {},
   videoElOrId,
-  isVideoMarker,
   isVideoYouTube,
   imgEl,
   interactiveEl,
@@ -81,7 +80,7 @@ function Header({
       }
     } else {
       mediaEl = html`<div></div>`;
-      VideoPlayer[`getMetadata${isVideoMarker ? 'FromDetailPage' : ''}`](videoElOrId, (err, metadata) => {
+      VideoPlayer.getMetadata(videoElOrId, (err, metadata) => {
         if (err) {
           return;
         }
@@ -267,7 +266,6 @@ function transformSection(section, meta) {
         if (videoEl) {
           config.videoElOrId = videoEl;
         } else if (node.name && !!node.name.match(VIDEO_MARKER_PATTERN)) {
-          config.isVideoMarker = true;
           config.isVideoYouTube = node.name.split('youtube')[1];
           config.videoElOrId = videoId = node.name.match(VIDEO_MARKER_PATTERN)[1];
         } else {

--- a/src/app/components/VideoEmbed/index.js
+++ b/src/app/components/VideoEmbed/index.js
@@ -73,20 +73,17 @@ function transformEl(el) {
     scrollplayPct
   };
 
-  const playerEl = isYouTube ? YouTubePlayer(Object.assign(playerOptions, { videoId })) : html`<div></div>`;
-
-  if (!isYouTube) {
-    VideoPlayer.getMetadata(videoId, (err, metadata) => {
-      if (err) {
-        return;
-      }
-
-      substitute(playerEl, VideoPlayer(Object.assign(playerOptions, metadata)));
-      invalidateClient();
-    });
-  }
-
-  substitute(el, VideoEmbed(Object.assign(options, { playerEl, captionEl })));
+  substitute(
+    el,
+    VideoEmbed(
+      Object.assign(options, {
+        playerEl: isYouTube
+          ? YouTubePlayer(Object.assign(playerOptions, { videoId }))
+          : VideoPlayer(Object.assign(playerOptions, { videoElOrId: videoId })),
+        captionEl
+      })
+    )
+  );
 }
 
 function transformMarker(marker) {

--- a/src/app/components/VideoEmbed/index.js
+++ b/src/app/components/VideoEmbed/index.js
@@ -76,7 +76,7 @@ function transformEl(el) {
   const playerEl = isYouTube ? YouTubePlayer(Object.assign(playerOptions, { videoId })) : html`<div></div>`;
 
   if (!isYouTube) {
-    VideoPlayer[`getMetadata${isMarker ? 'FromDetailPage' : ''}`](videoId, (err, metadata) => {
+    VideoPlayer.getMetadata(videoId, (err, metadata) => {
       if (err) {
         return;
       }

--- a/src/app/components/VideoEmbed/index.js
+++ b/src/app/components/VideoEmbed/index.js
@@ -65,6 +65,7 @@ function transformEl(el) {
   const scrollplayPct = scrollplayPctString.length > 0 && Math.max(0, Math.min(100, +scrollplayPctString));
 
   const playerOptions = {
+    videoId,
     ratios: getRatios(configSC),
     title,
     isAmbient: configSC.indexOf('ambient') > -1,
@@ -77,9 +78,7 @@ function transformEl(el) {
     el,
     VideoEmbed(
       Object.assign(options, {
-        playerEl: isYouTube
-          ? YouTubePlayer(Object.assign(playerOptions, { videoId }))
-          : VideoPlayer(Object.assign(playerOptions, { videoElOrId: videoId })),
+        playerEl: (isYouTube ? YouTubePlayer : VideoPlayer)(playerOptions),
         captionEl
       })
     )

--- a/src/app/components/VideoPlayer/index.js
+++ b/src/app/components/VideoPlayer/index.js
@@ -18,7 +18,7 @@ const FUZZY_INCREMENT_INTERVAL = 1000 / FUZZY_INCREMENT_FPS;
 const DEFAULT_RATIO = '16x9';
 
 function VideoPlayer({
-  videoElOrId,
+  videoId,
   ratios = {},
   title,
   isAmbient,
@@ -229,7 +229,7 @@ function VideoPlayer({
     jumpBy: time => jumpTo(videoEl.currentTime + time)
   };
 
-  getMetadata(videoElOrId, (err, metadata) => {
+  getMetadata(videoId, (err, metadata) => {
     if (err) {
       return;
     }

--- a/src/app/components/VideoPlayer/index.js
+++ b/src/app/components/VideoPlayer/index.js
@@ -1,6 +1,5 @@
 // External
 const html = require('bel');
-const raf = require('raf');
 
 // Ours
 const { MQ, MS_VERSION, SMALLEST_IMAGE } = require('../../../constants');
@@ -11,7 +10,7 @@ const { PLACEHOLDER_PROPERTY, resize } = require('../Picture');
 const { blurImage } = require('../Picture/blur');
 const VideoControls = require('../VideoControls');
 const { trackProgress } = require('./stats');
-const { getMetadata, getMetadataFromDetailPage, hasAudio } = require('./utils');
+const { getMetadata, hasAudio } = require('./utils');
 require('./index.scss');
 
 const FUZZY_INCREMENT_FPS = 30;
@@ -92,35 +91,41 @@ function VideoPlayer({
     videoEl.muted = true;
   }
 
-  if (posterURL) {
-    videoEl.poster = SMALLEST_IMAGE;
-    // Pick the aspect ratio based on config and the current viewport
-    // size (similar to how the video source is chosen below).
-    // Eventually, we'd like to update both of these as the viewport
-    // changes, but it's not a priority right now.
-    videoEl.style.backgroundImage = `url("${resize({
-      url: posterURL,
-      size: 'sm',
-      ratio: ratios[isInitiallySmallViewport ? 'sm' : 'md']
-    })}")`;
+  function attachAssets() {
+    if (posterURL) {
+      videoEl.poster = SMALLEST_IMAGE;
+      // Pick the aspect ratio based on config and the current viewport
+      // size (similar to how the video source is chosen below).
+      // Eventually, we'd like to update both of these as the viewport
+      // changes, but it's not a priority right now.
+      videoEl.style.backgroundImage = `url("${resize({
+        url: posterURL,
+        size: 'sm',
+        ratio: ratios[isInitiallySmallViewport ? 'sm' : 'lg']
+      })}")`;
+    }
+
+    // If we're on mobile, and have more than one high resolution source, use the second
+    // highest; otherwise, use the first source (of any resolution).
+    // Note: Only Phase 1 (Desktop) sources have width/height defined, making it the
+    // only template that can differentiate its high resolution sources.
+    const highResSources = sources.filter(source => source.width >= 1080).sort((a, b) => {
+      // Wide videos should come before squares
+      if (a.width > b.width) return -1;
+      if (b.width > a.width) return 1;
+      return 0;
+    });
+    const source = (highResSources.length ? highResSources : sources)[
+      highResSources.length > 1 && isInitiallySmallViewport ? 1 : 0
+    ];
+
+    if (source) {
+      videoEl.src = source.src;
+    }
   }
 
-  // If we're on mobile, and have more than one high resolution source, use the second
-  // highest; otherwise, use the first source (of any resolution).
-  // Note: Only Phase 1 (Desktop) sources have width/height defined, making it the
-  // only template that can differentiate its high resolution sources.
-  const highResSources = sources.filter(source => source.width >= 1080).sort((a, b) => {
-    // Wide videos should come before squares
-    if (a.width > b.width) return -1;
-    if (b.width > a.width) return 1;
-    return 0;
-  });
-  const source = (highResSources.length ? highResSources : sources)[
-    highResSources.length > 1 && isInitiallySmallViewport ? 1 : 0
-  ];
-
-  if (source) {
-    videoEl.src = source.src;
+  if (sources.length) {
+    attachAssets();
   }
 
   function nextFuzzyIncrement() {
@@ -375,4 +380,3 @@ subscribe(function _checkIfVideoPlayersNeedToUpdateUIBasedOnMedia() {
 
 module.exports = VideoPlayer;
 module.exports.getMetadata = getMetadata;
-module.exports.getMetadataFromDetailPage = getMetadataFromDetailPage;

--- a/src/app/components/VideoPlayer/utils.js
+++ b/src/app/components/VideoPlayer/utils.js
@@ -36,19 +36,7 @@ function getSources(item, sortProp = 'bitrate') {
   }));
 }
 
-function getMetadata(videoElOrId, done) {
-  let [videoEl, videoId] = isElement(videoElOrId) ? [videoElOrId, null] : [null, videoElOrId];
-
-  if (videoEl) {
-    let parentEl = videoEl.parentElement;
-
-    while (parentEl.className.indexOf('media-wrapper-dl') === -1 && parentEl !== document.documentElement) {
-      parentEl = parentEl.parentElement;
-    }
-
-    videoId = ((parentEl.getAttribute('data-uri') || '').match(/\d+/) || [null])[0];
-  }
-
+function getMetadata(videoId, done) {
   if (!videoId) {
     return done(new Error(NO_CMID_ERROR));
   }

--- a/src/app/components/VideoPlayer/utils.js
+++ b/src/app/components/VideoPlayer/utils.js
@@ -1,145 +1,70 @@
-// External
-const raf = require('raf');
-const xhr = require('xhr');
-
 // Ours
-const { CSS_URL } = require('../../../constants');
-const { getMeta } = require('../../meta');
-const { $, $$, isElement } = require('../../utils/dom');
+const { getDocument } = require('../../utils/capi');
+const { isElement } = require('../../utils/dom');
 
-const NEWLINES_PATTERN = /[\n\r]/g;
-const ERROR_UNRECOGNISED = 'Unrecognised video detail page template';
+const NO_CMID_ERROR = 'No CMID available for video';
 
-function formatSources(sources, sortProp = 'bitrate') {
-  return sources.sort((a, b) => +b[sortProp] - +a[sortProp]).map(source => ({
-    src: source.src || source.url,
-    type: source.type || source.contentType,
-    width: +source.width || 0,
-    height: +source.height || 0
+function pickImageURL(media) {
+  return (media.filter(thumbnail => thumbnail.ratio === '16x9').sort((a, b) => b.size - a.size)[0] || {}).url;
+}
+
+function getPosterURL(item, done) {
+  if (item.thumbnailLink) {
+    return done(pickImageURL(item.thumbnailLink.media));
+  }
+
+  if (item.relatedItems) {
+    const relatedImage = item.relatedItems.filter(relatedItem => relatedItem.docType === 'Image')[0];
+
+    if (relatedImage) {
+      // Must fetch image to get renditions. Allowed to fail.
+      return getDocument(relatedImage.id, (err, item) => {
+        done(item ? pickImageURL(item.media) : null);
+      });
+    }
+  }
+
+  done();
+}
+
+function getSources(item, sortProp = 'bitrate') {
+  return item.renditions.sort((a, b) => +b[sortProp] - +a[sortProp]).map(rendition => ({
+    src: rendition.src || rendition.url,
+    type: rendition.type || rendition.contentType,
+    width: +rendition.width || 0,
+    height: +rendition.height || 0
   }));
 }
 
-function getMetadata(videoElOrId, callback) {
-  let wasCalled;
+function getMetadata(videoElOrId, done) {
+  let [videoEl, videoId] = isElement(videoElOrId) ? [videoElOrId, null] : [null, videoElOrId];
 
-  function done(err, metadata) {
-    if (!wasCalled) {
-      wasCalled = true;
-      raf(() => {
-        callback(err, metadata);
-      });
+  if (videoEl) {
+    let parentEl = videoEl.parentElement;
+
+    while (parentEl.className.indexOf('media-wrapper-dl') === -1 && parentEl !== document.documentElement) {
+      parentEl = parentEl.parentElement;
     }
+
+    videoId = ((parentEl.getAttribute('data-uri') || '').match(/\d+/) || [null])[0];
   }
 
-  if (isElement(videoElOrId)) {
-    if (videoElOrId.className.indexOf('jw-') > -1) {
-      // JWPLayer <video> with src attribute and nearby element with poster as a background-image
-      done(null, {
-        posterURL: (videoElOrId.parentElement.nextElementSibling.style.backgroundImage.match(CSS_URL) || [, ''])[1],
-        sources: formatSources([videoElOrId])
-      });
-    } else {
-      // <video> with poster attribute and <source> children
-      done(null, {
-        posterURL: videoElOrId.poster,
-        sources: formatSources($$('source', videoElOrId))
-      });
-    }
-  } else if ('WCMS' in window) {
-    // Phase 2
-    // * Poster & sources are nested inside global `WCMS` object
-
-    Object.keys(WCMS.pluginCache.plugins.videoplayer).some(key => {
-      const config = WCMS.pluginCache.plugins.videoplayer[key][0].videos[0];
-
-      if (config.url.indexOf(videoElOrId) > -1) {
-        done(null, {
-          posterURL: config.thumbnail.replace('-thumbnail', '-large'),
-          sources: formatSources(config.sources, 'label')
-        });
-
-        return true;
-      }
-    });
-  } else if ('inlineVideoData' in window) {
-    // Phase 1 (Standard)
-    // * Poster may be inferred from original embed's partial jwplayer transform
-    // * Sources are nested inside global `inlineVideoData` object
-
-    const relatedMedia = getMeta().relatedMedia;
-
-    $$('.inline-content.video[data-inline-video-data-index]')
-      .concat(relatedMedia ? [relatedMedia] : [])
-      .some(el => {
-        if ($(`[href*="/${videoElOrId}"]`, el)) {
-          const posterEl = $('img', el) || $('.inline-video, .jwplayer-video', el);
-
-          done(null, {
-            posterURL: posterEl ? (posterEl.style.backgroundImage.match(CSS_URL) || [, posterEl.src])[1] : null,
-            sources: formatSources(window.inlineVideoData[el.getAttribute('data-inline-video-data-index')])
-          });
-
-          return true;
-        }
-      });
-  } else {
-    // Phase 1 (Mobile):
-    // * Doesn't embed video; only teases to it.
-    // * Must fetch video detail page (Phase 1 always fetches from Standard)...
-    // * ...then parse posterURL and sources, based on the page template
-
-    getMetadataFromDetailPage(videoElOrId, done);
+  if (!videoId) {
+    return done(new Error(NO_CMID_ERROR));
   }
-}
 
-function detailPageURLFromId(id) {
-  return `${(window.location.origin || '').replace('mobile', 'www')}/news/${id}?pfm=ms`;
-}
-
-function getMetadataFromDetailPage(id, callback) {
-  xhr({ url: detailPageURLFromId(id) }, (err, response, body) => {
-    if (err || response.statusCode !== 200) {
-      return callback(err || new Error(response.statusCode));
+  getDocument(videoId, (err, item) => {
+    if (err) {
+      return done(err);
     }
 
-    const doc = new DOMParser().parseFromString(body, 'text/html');
-
-    if (body.indexOf('WCMS.pluginCache') > -1) {
-      // Phase 2
-      // * Poster can be selected from the DOM
-      // * Sources can be parsed from JS that would nest them under the global `WCMS` object
-
-      const imgEl = doc.querySelector('.view-inlineMediaPlayer img');
-
-      return callback(null, {
-        posterURL: imgEl.getAttribute('src').replace('-thumbnail', '-large'),
-        alternativeText: imgEl.getAttribute('alt'),
-        sources: formatSources(
-          JSON.parse(body.replace(NEWLINES_PATTERN, '').match(/"sources":(\[.*\]),"addDownload"/)[1])
-        )
-      });
-    } else if (body.indexOf('inlineVideoData') > -1) {
-      // Phase 1 (Standard)
-      // * Poster can be selected from the DOM
-      // * Sources can be parsed from JS that would nest them under the global `inlineVideoData` object
-
-      const imgEl = doc.querySelector('.inline-video img');
-
-      return callback(null, {
-        posterURL: imgEl.getAttribute('src'),
-        alternativeText: imgEl.getAttribute('alt'),
-        sources: formatSources(
-          JSON.parse(
-            body
-              .replace(NEWLINES_PATTERN, '')
-              .match(/inlineVideoData\.push\((\[.*\])\)/)[1]
-              .replace(/'/g, '"')
-          )
-        )
-      });
-    }
-
-    callback(new Error(ERROR_UNRECOGNISED));
+    getPosterURL(item, posterURL =>
+      done(null, {
+        alternativeText: item.title,
+        posterURL,
+        sources: getSources(item)
+      })
+    );
   });
 }
 
@@ -148,5 +73,4 @@ function hasAudio(el) {
 }
 
 module.exports.getMetadata = getMetadata;
-module.exports.getMetadataFromDetailPage = getMetadataFromDetailPage;
 module.exports.hasAudio = hasAudio;


### PR DESCRIPTION
We're doing away with the horrible pattern that currently exists within Odyssey, where VideoPlayers are rendered in a bunch of places, first as placeholder `div`s, then substituted with proper components once their required props (poster image and .mp4 source URLs) are asynchronously fetched & parsed from video detail page HTML (ewwww).

The existing pattern was due to the variety of ways that Core can render videos (with and without the data we need to make our own components) across different phases / platforms.

Now, we're using the Content API everywhere (even if pieces of the metadata can be parsed from the current article's DOM / HTML). Consistency will be more important than # of requests going forward.

The VideoPlayer component now loads its own metadata once rendered as a shell, so the parent DOM no longer has to worry about anything other than passing in a CMID (or a `<video>` element in rare cases).

So many little hacks have just evaporated in this PR, and hopefully this will make things much cleaner if we port Odyssey's components to React in the future.