### PR TITLE
XL breakpoint

### DIFF
--- a/src/app/components/Block/content.scss
+++ b/src/app/components/Block/content.scss
@@ -12,19 +12,7 @@
   max-width: 40rem;
   min-height: 100vh;
 
-  @media #{$mq-lg} and #{$mq-not-xl} {
-    &.is-left,
-    &.is-right {
-      max-width: 35rem;
-    }
-
-    .has-inset-media > &.is-left,
-    .has-inset-media > &.is-right {
-      max-width: 30rem;
-    }
-  }
-
-  @media #{$mq-lg} {
+  @media #{$mq-gt-md} {
     &.is-left {
       margin-left: calc(25% - 12.5rem);
 
@@ -39,6 +27,18 @@
       .has-inset-media > & {
         margin-right: calc(25% - 14rem);
       }
+    }
+  }
+
+  @media #{$mq-lg} {
+    &.is-left,
+    &.is-right {
+      max-width: 35rem;
+    }
+
+    .has-inset-media > &.is-left,
+    .has-inset-media > &.is-right {
+      max-width: 30rem;
     }
   }
 
@@ -61,7 +61,7 @@
     margin: 0 !important;
     padding: 0.75rem 1.75rem;
 
-    @media #{$mq-lg} {
+    @media #{$mq-gt-md} {
       padding: 1.125rem 1.75rem;
     }
   }
@@ -81,7 +81,7 @@
   }
 
   .is-piecemeal.has-inset-media > &:nth-child(2) > :first-child {
-    @media #{$mq-lg} {
+    @media #{$mq-gt-md} {
       margin-top: 40vh !important;
     }
   }
@@ -109,7 +109,7 @@
   & > :first-child {
     padding-top: 1.5rem;
 
-    @media #{$mq-lg} {
+    @media #{$mq-gt-md} {
       padding-top: 2.25rem;
     }
 
@@ -121,7 +121,7 @@
   & > :last-child {
     padding-bottom: 1.5rem;
 
-    @media #{$mq-lg} {
+    @media #{$mq-gt-md} {
       padding-bottom: 2.25rem;
     }
 
@@ -154,7 +154,7 @@
         font-size: 1.25rem;
       }
 
-      @media #{$mq-lg} {
+      @media #{$mq-gt-md} {
         font-size: 1.375rem;
       }
     }

--- a/src/app/components/Block/index.js
+++ b/src/app/components/Block/index.js
@@ -70,7 +70,8 @@ function Block({
   ratios = {
     sm: ratios.sm || '3x4',
     md: ratios.md || '1x1',
-    lg: ratios.lg
+    lg: ratios.lg,
+    xl: ratios.xl
   };
 
   let mediaEl;
@@ -156,46 +157,44 @@ function Block({
   const blockEl = html`
     <div class="${className}">
       ${mediaContainerEl}
-      ${
-        isPiecemeal
-          ? contentEls.reduce((memo, contentEl) => {
-              const piecemeallAlignment = contentEl.getAttribute('data-alignment');
-              const piecemealBackgroundIndex = contentEl.getAttribute('data-background-index');
-              const piecemealLightDark = contentEl.getAttribute('data-lightdark');
-              let piecemealContentClassName = contentClassName;
+      ${isPiecemeal
+        ? contentEls.reduce((memo, contentEl) => {
+            const piecemeallAlignment = contentEl.getAttribute('data-alignment');
+            const piecemealBackgroundIndex = contentEl.getAttribute('data-background-index');
+            const piecemealLightDark = contentEl.getAttribute('data-lightdark');
+            let piecemealContentClassName = contentClassName;
 
-              // Override the light/dark from the Block if a marker was given
-              if (piecemealLightDark) {
-                piecemealContentClassName = piecemealContentClassName.replace(
-                  /\su-richtext(-invert)?/,
-                  ` u-richtext${piecemealLightDark === 'light' ? '' : '-invert'}`
-                );
-              }
+            // Override the light/dark from the Block if a marker was given
+            if (piecemealLightDark) {
+              piecemealContentClassName = piecemealContentClassName.replace(
+                /\su-richtext(-invert)?/,
+                ` u-richtext${piecemealLightDark === 'light' ? '' : '-invert'}`
+              );
+            }
 
-              // Override the left/right from the Block if marker has it
-              if (piecemeallAlignment) {
-                piecemealContentClassName = piecemealContentClassName.replace(
-                  /\sis-(left|right)/,
-                  `${piecemeallAlignment === 'center' ? '' : ` is-${piecemeallAlignment}`}`
-                );
-              }
+            // Override the left/right from the Block if marker has it
+            if (piecemeallAlignment) {
+              piecemealContentClassName = piecemealContentClassName.replace(
+                /\sis-(left|right)/,
+                `${piecemeallAlignment === 'center' ? '' : ` is-${piecemeallAlignment}`}`
+              );
+            }
 
-              if (memo.length === 0 || !isGrouped || (piecemealBackgroundIndex && piecemealBackgroundIndex.length)) {
-                memo.push(html`
-                  <div class="${piecemealContentClassName}">${contentEl}</div>
-                `);
-              } else {
-                memo[memo.length - 1].appendChild(contentEl);
-              }
+            if (memo.length === 0 || !isGrouped || (piecemealBackgroundIndex && piecemealBackgroundIndex.length)) {
+              memo.push(html`
+                <div class="${piecemealContentClassName}">${contentEl}</div>
+              `);
+            } else {
+              memo[memo.length - 1].appendChild(contentEl);
+            }
 
-              return memo;
-            }, [])
-          : contentEls.length > 0
-          ? html`
-              <div class="${contentClassName}">${contentEls}</div>
-            `
-          : null
-      }
+            return memo;
+          }, [])
+        : contentEls.length > 0
+        ? html`
+            <div class="${contentClassName}">${contentEls}</div>
+          `
+        : null}
     </div>
   `;
 

--- a/src/app/components/Block/index.scss
+++ b/src/app/components/Block/index.scss
@@ -7,7 +7,7 @@
   min-height: 100vh;
   line-height: 1.5;
 
-  @media #{$mq-landscape} and #{$mq-not-lg}, #{$mq-lg} {
+  @media #{$mq-gt-md}, #{$mq-landscape} and #{$mq-lt-lg} {
     min-height: 56.25vw;
   }
 

--- a/src/app/components/Block/media.scss
+++ b/src/app/components/Block/media.scss
@@ -31,7 +31,7 @@
   }
 
   .has-inset-media & > * {
-    @media #{$mq-lg} {
+    @media #{$mq-gt-md} {
       position: fixed;
       transform: translate(0, -50%);
       top: 50vh;
@@ -53,7 +53,7 @@
   }
 
   .has-inset-media.has-left & > * {
-    @media #{$mq-lg} {
+    @media #{$mq-gt-md} {
       right: calc(30% - 16rem);
       left: auto;
     }
@@ -64,7 +64,7 @@
   }
 
   .has-inset-media.has-right & > * {
-    @media #{$mq-lg} {
+    @media #{$mq-gt-md} {
       right: auto;
       left: calc(30% - 16rem);
     }
@@ -75,7 +75,7 @@
   }
 
   .has-inset-media &:not(.is-fixed) {
-    @media #{$mq-not-lg} {
+    @media #{$mq-lt-lg} {
       clip: rect(0, auto, auto, 0);
       -webkit-clip-path: inset(0 0 0 0);
     }
@@ -84,7 +84,7 @@
   .has-inset-media &:not(.is-fixed) > * {
     position: absolute;
 
-    @media #{$mq-not-lg} {
+    @media #{$mq-lt-lg} {
       position: fixed;
       top: 0;
       left: 0;
@@ -123,7 +123,7 @@
       background-image: $gradient-white-vertical-50-0-100-60;
     }
 
-    @media #{$mq-lg} {
+    @media #{$mq-gt-md} {
       .has-left.is-not-piecemeal &,
       .has-right.is-not-piecemeal & {
         background-color: transparent;

--- a/src/app/components/Caption/index.scss
+++ b/src/app/components/Caption/index.scss
@@ -9,13 +9,13 @@
   padding-bottom: 0.4rem;
   font-family: $font-sans;
 
-  @media #{$mq-not-lg} {
+  @media #{$mq-lt-lg} {
     padding-left: $layout-fluid-padding;
     padding-right: $layout-fluid-padding;
   }
 
   .u-full & {
-    @media #{$mq-lg} {
+    @media #{$mq-gt-md} {
       padding-left: $layout-fixed-padding;
       padding-right: $layout-fixed-padding;
     }
@@ -27,7 +27,7 @@
     background-color: $color-black-transparent-60;
     color: $color-white;
 
-    @media #{$mq-lg} {
+    @media #{$mq-gt-md} {
       padding-left: $layout-fluid-padding;
       padding-right: $layout-fluid-padding;
     }
@@ -35,7 +35,7 @@
 
   .u-richtext .u-pull-left &,
   .u-richtext .u-pull-right & {
-    @media #{$mq-not-sm} {
+    @media #{$mq-gt-sm} {
       padding-left: 0;
       padding-right: 0;
     }

--- a/src/app/components/Gallery/index.js
+++ b/src/app/components/Gallery/index.js
@@ -468,7 +468,8 @@ function transformSection(section) {
           ratios: {
             sm: ratios.sm || '3x4',
             md: ratios.md,
-            lg: ratios.lg
+            lg: ratios.lg,
+            xl: ratios.xl
           },
           isInvariablyAmbient: true
         });
@@ -478,7 +479,8 @@ function transformSection(section) {
             ratios: {
               sm: ratios.sm || '3x2',
               md: ratios.md || '16x9',
-              lg: ratios.lg
+              lg: ratios.lg,
+              xl: ratios.xl
             },
             isInvariablyAmbient: true
           }),
@@ -487,7 +489,8 @@ function transformSection(section) {
             ratios: {
               sm: ratios.sm || '1x1',
               md: ratios.md,
-              lg: ratios.lg || '3x2'
+              lg: ratios.lg || '3x2',
+              xl: ratios.xl || '3x2'
             },
             isInvariablyAmbient: true
           }),
@@ -496,7 +499,8 @@ function transformSection(section) {
             ratios: {
               sm: ratios.sm || '3x4',
               md: ratios.md || '4x3',
-              lg: ratios.lg || '4x3'
+              lg: ratios.lg || '4x3',
+              xl: ratios.xl || '4x3'
             },
             isInvariablyAmbient: true
           })
@@ -532,7 +536,8 @@ function transformSection(section) {
             ratios: {
               sm: ratios.sm || '3x4',
               md: ratios.md,
-              lg: ratios.lg
+              lg: ratios.lg,
+              xl: ratios.xl
             },
             linkUrl
           }),
@@ -543,7 +548,8 @@ function transformSection(section) {
               ratios: {
                 sm: ratios.sm || '3x2',
                 md: ratios.md || '16x9',
-                lg: ratios.lg
+                lg: ratios.lg,
+                xl: ratios.xl
               },
               linkUrl
             }),
@@ -553,7 +559,8 @@ function transformSection(section) {
               ratios: {
                 sm: ratios.sm || '1x1',
                 md: ratios.md,
-                lg: ratios.lg || '3x2'
+                lg: ratios.lg || '3x2',
+                xl: ratios.xl || '3x2'
               },
               linkUrl
             }),
@@ -563,7 +570,8 @@ function transformSection(section) {
               ratios: {
                 sm: ratios.sm || '3x4',
                 md: ratios.md || '4x3',
-                lg: ratios.lg || '4x3'
+                lg: ratios.lg || '4x3',
+                xl: ratios.xl || '4x3'
               },
               linkUrl
             })

--- a/src/app/components/Gallery/index.scss
+++ b/src/app/components/Gallery/index.scss
@@ -18,7 +18,7 @@
   padding-left: $layout-fluid-padding;
   padding-right: $layout-fluid-padding;
 
-  @media #{$mq-not-lg} {
+  @media #{$mq-lt-lg} {
     .is-mosaic & {
       padding-left: 0;
       padding-right: 0;
@@ -34,7 +34,7 @@
     width: cells(10);
   }
 
-  @media #{$mq-lg} {
+  @media #{$mq-gt-md} {
     padding-left: $layout-fixed-padding;
     padding-right: $layout-fixed-padding;
     width: $layout-fixed;
@@ -47,7 +47,7 @@
   }
 
   .is-mosaic & > .Caption {
-    @media #{$mq-lg} {
+    @media #{$mq-gt-md} {
       padding-top: 0;
       padding-left: 0;
       padding-right: 0;
@@ -71,7 +71,7 @@
     }
   }
 
-  @media #{$mq-lg} {
+  @media #{$mq-gt-md} {
     margin: 0 -1.25rem;
 
     .is-mosaic & {
@@ -86,7 +86,7 @@
   transition: transform 0.125s ease-out;
   will-change: transform, left;
 
-  @media #{$mq-lg} {
+  @media #{$mq-gt-md} {
     transition-duration: 0.25s;
   }
 
@@ -139,7 +139,7 @@
     }
   }
 
-  @media #{$mq-lg} {
+  @media #{$mq-gt-md} {
     padding: 0 1.25rem;
 
     .is-mosaic & {
@@ -157,7 +157,7 @@
     transition: opacity 0.125s;
     will-change: opacity;
 
-    @media #{$mq-lg} {
+    @media #{$mq-gt-md} {
       transition-duration: 0.25s;
     }
 
@@ -192,7 +192,7 @@
     transition: opacity 0.125s;
     will-change: opacity;
 
-    @media #{$mq-lg} {
+    @media #{$mq-gt-md} {
       margin-left: -$layout-fixed-padding;
       transition-duration: 0.25s;
     }
@@ -203,7 +203,7 @@
     transition-delay: 0.125s;
     pointer-events: all;
 
-    @media #{$mq-lg} {
+    @media #{$mq-gt-md} {
       transition-delay: 0.25s;
     }
   }
@@ -234,7 +234,7 @@
       max-width: calc(100% - 0.5rem);
     }
 
-    @media #{$mq-lg} {
+    @media #{$mq-gt-md} {
       max-width: calc(100% - 0.625rem);
     }
   }
@@ -261,7 +261,7 @@
   width: 100%;
   pointer-events: none;
 
-  @media #{$mq-lg} {
+  @media #{$mq-gt-md} {
     padding: 0 $layout-fixed-padding;
   }
 

--- a/src/app/components/GalleryEmbed/index.js
+++ b/src/app/components/GalleryEmbed/index.js
@@ -100,7 +100,8 @@ function transformEl(el) {
             ratios: {
               sm: ratios.sm || '3x4',
               md: ratios.md,
-              lg: ratios.lg
+              lg: ratios.lg,
+              xl: ratios.xl
             },
             linkUrl
           }),
@@ -111,7 +112,8 @@ function transformEl(el) {
               ratios: {
                 sm: ratios.sm || '3x2',
                 md: ratios.md || '16x9',
-                lg: ratios.lg
+                lg: ratios.lg,
+                xl: ratios.xl
               },
               linkUrl
             }),
@@ -121,7 +123,8 @@ function transformEl(el) {
               ratios: {
                 sm: ratios.sm || '1x1',
                 md: ratios.md,
-                lg: ratios.lg || '3x2'
+                lg: ratios.lg || '3x2',
+                xl: ratios.xl || '3x2'
               },
               linkUrl
             }),
@@ -131,7 +134,8 @@ function transformEl(el) {
               ratios: {
                 sm: ratios.sm || '3x4',
                 md: ratios.md || '4x3',
-                lg: ratios.lg || '4x3'
+                lg: ratios.lg || '4x3',
+                xl: ratios.xl || '4x3'
               },
               linkUrl
             })

--- a/src/app/components/Header/index.js
+++ b/src/app/components/Header/index.js
@@ -51,7 +51,8 @@ function Header({
   ratios = {
     sm: ratios.sm || (isLayered ? '3x4' : '1x1'),
     md: ratios.md || (isLayered ? '1x1' : '3x2'),
-    lg: ratios.lg || (isAbreast ? '1x1' : null)
+    lg: isAbreast ? '3x4' : ratios.lg,
+    xl: isAbreast ? '1x1' : ratios.xl
   };
 
   let mediaEl;

--- a/src/app/components/Header/index.js
+++ b/src/app/components/Header/index.js
@@ -51,7 +51,7 @@ function Header({
   ratios = {
     sm: ratios.sm || (isLayered ? '3x4' : '1x1'),
     md: ratios.md || (isLayered ? '1x1' : '3x2'),
-    lg: ratios.lg || (isAbreast ? '3x4' : null)
+    lg: ratios.lg || (isAbreast ? '1x1' : null)
   };
 
   let mediaEl;

--- a/src/app/components/Header/index.scss
+++ b/src/app/components/Header/index.scss
@@ -9,7 +9,7 @@ $header-abreast-margin: 2.5rem;
   line-height: 1.5;
   background-color: $color-grey-50;
 
-  @media #{$mq-not-sm} {
+  @media #{$mq-gt-sm} {
     font-size: 1.25rem;
   }
 
@@ -41,7 +41,7 @@ $header-abreast-margin: 2.5rem;
     }
   }
 
-  @media #{$mq-lg} {
+  @media #{$mq-gt-md} {
     &.is-abreast {
       display: flex;
       flex-direction: row-reverse;
@@ -108,12 +108,13 @@ $header-abreast-margin: 2.5rem;
     background-image: $gradient-white-vertical-0-0-100-60;
   }
 
-  @media #{$mq-lg} {
+  @media #{$mq-gt-md} {
     .is-abreast > & {
       flex-grow: 1;
       -ms-flex: 1 0 50%;
-      max-width: calc(100vh - #{$abc-nav-height + $header-content-peek + $header-abreast-margin * 2});
       max-height: calc(100vh - #{$abc-nav-height + $header-content-peek + $header-abreast-margin * 2});
+      // Enforce 3x4 aspect ratio
+      max-width: calc(75vh - #{$abc-nav-height + $header-content-peek + $header-abreast-margin * 2});
 
       &::after {
         content: none;
@@ -129,7 +130,9 @@ $header-abreast-margin: 2.5rem;
     .is-abreast > & {
       flex-grow: 0;
       -ms-flex: 0 0 50%;
+      // Enforce 1x1 aspect ratio
       width: calc(100vh - #{$abc-nav-height + $header-content-peek + $header-abreast-margin * 2});
+      max-width: none;
     }
   }
 }
@@ -153,13 +156,13 @@ $header-abreast-margin: 2.5rem;
     margin-right: calc(#{cells(1)} + #{$layout-fluid-padding});
   }
 
-  @media #{$mq-lg} {
+  @media #{$mq-gt-md} {
     margin-left: auto;
     margin-right: auto;
     width: $layout-fixed - $layout-fixed-gutter;
   }
 
-  @media #{$mq-lg} {
+  @media #{$mq-gt-md} {
     .is-abreast > & {
       display: flex;
       flex-direction: column;
@@ -198,7 +201,7 @@ $header-abreast-margin: 2.5rem;
     padding-right: cells(1, 10);
   }
 
-  @media #{$mq-lg} {
+  @media #{$mq-gt-md} {
     padding-left: calc(#{cells(1)} + #{$layout-fixed-padding});
     padding-right: calc(#{cells(1)} + #{$layout-fixed-padding});
   }
@@ -235,12 +238,12 @@ $header-abreast-margin: 2.5rem;
     height: 0.125rem;
     background-color: $color-grey-300-transparent-70;
 
-    @media #{$mq-not-sm} {
+    @media #{$mq-gt-sm} {
       width: 18rem;
     }
   }
 
-  @media #{$mq-lg} {
+  @media #{$mq-gt-md} {
     .is-abreast &::after {
       margin-left: 0;
     }
@@ -256,7 +259,7 @@ $header-abreast-margin: 2.5rem;
   .Header > .Header-content > & {
     font-size: 1.125rem;
 
-    @media #{$mq-not-sm} {
+    @media #{$mq-gt-sm} {
       font-size: 1.25rem;
     }
   }

--- a/src/app/components/Header/index.scss
+++ b/src/app/components/Header/index.scss
@@ -112,7 +112,7 @@ $header-abreast-margin: 2.5rem;
     .is-abreast > & {
       flex-grow: 1;
       -ms-flex: 1 0 50%;
-      max-width: calc(75vh - 5rem); // Maintain 3:4 aspect ratio, based on max-height (below)
+      max-width: calc(100vh - #{$abc-nav-height + $header-content-peek + $header-abreast-margin * 2});
       max-height: calc(100vh - #{$abc-nav-height + $header-content-peek + $header-abreast-margin * 2});
 
       &::after {
@@ -129,7 +129,7 @@ $header-abreast-margin: 2.5rem;
     .is-abreast > & {
       flex-grow: 0;
       -ms-flex: 0 0 50%;
-      width: calc(940px - #{$header-abreast-margin * 2});
+      width: calc(100vh - #{$abc-nav-height + $header-content-peek + $header-abreast-margin * 2});
     }
   }
 }

--- a/src/app/components/ImageEmbed/index.js
+++ b/src/app/components/ImageEmbed/index.js
@@ -54,7 +54,8 @@ function transformEl(el, preserveOriginalRatio) {
       ratios: {
         sm: ratios.sm || '3x4',
         md: ratios.md || '4x3',
-        lg: ratios.lg
+        lg: ratios.lg,
+        xl: ratios.xl
       },
       preserveOriginalRatio,
       linkUrl

--- a/src/app/components/Main/index.scss
+++ b/src/app/components/Main/index.scss
@@ -44,7 +44,7 @@
         margin: 4rem auto 1.5rem;
       }
 
-      @media #{$mq-lg} {
+      @media #{$mq-gt-md} {
         margin: 5rem auto 1.5rem;
       }
     }
@@ -53,7 +53,7 @@
       padding-bottom: 0.5rem;
     }
 
-    @media #{$mq-lg} {
+    @media #{$mq-gt-md} {
       padding-bottom: 1rem;
     }
   }

--- a/src/app/components/MasterGallery/index.scss
+++ b/src/app/components/MasterGallery/index.scss
@@ -57,7 +57,7 @@ html.is-master-gallery-open {
     width: 100%;
     max-width: $layout-fixed - $layout-fixed-gutter;
 
-    @media #{$mq-lg} {
+    @media #{$mq-gt-md} {
       font-size: 1rem !important;
       line-height: 1.625rem;
 

--- a/src/app/components/Picture/index.js
+++ b/src/app/components/Picture/index.js
@@ -10,11 +10,11 @@ const { blurImage } = require('./blur');
 require('./index.scss');
 
 const SIZES = {
-  '16x9': { sm: '700x394', md: '940x529', lg: '2150x1210' },
-  '3x2': { sm: '700x467', md: '940x627', lg: '940x627' },
-  '4x3': { sm: '700x525', md: '940x705', lg: '940x705' },
-  '1x1': { sm: '700x700', md: '940x940', lg: '1400x1400' },
-  '3x4': { sm: '700x933', md: '940x1253', lg: '940x1253' }
+  '16x9': { sm: '700x394', md: '940x529', lg: '2150x1210', xl: '2150x1210' },
+  '3x2': { sm: '700x467', md: '940x627', lg: '940x627', xl: '940x627' },
+  '4x3': { sm: '700x525', md: '940x705', lg: '940x705', xl: '940x705' },
+  '1x1': { sm: '700x700', md: '940x940', lg: '1400x1400', xl: '1400x1400' },
+  '3x4': { sm: '700x933', md: '940x1253', lg: '940x1253', xl: '940x1253' }
 };
 
 const P1_RATIO_SIZE_PATTERN = /(\d+x\d+)-(\d+x\d+)/;
@@ -22,7 +22,8 @@ const P2_RATIO_SIZE_PATTERN = /(\d+x\d+)-([a-z]+)/;
 const DEFAULTS = {
   SM_RATIO: '1x1',
   MD_RATIO: '3x2',
-  LG_RATIO: '16x9'
+  LG_RATIO: '16x9',
+  XL_RATIO: '16x9'
 };
 const PLACEHOLDER_PROPERTY = '--placeholder-image';
 const IMAGE_LOAD_RANGE = 1;
@@ -44,15 +45,19 @@ function Picture({
       ? {
           sm: originalRatio,
           md: originalRatio,
-          lg: originalRatio
+          lg: originalRatio,
+          xl: originalRatio
         }
       : {
           sm: ratios.sm || DEFAULTS.SM_RATIO,
           md: ratios.md || DEFAULTS.MD_RATIO,
-          lg: ratios.lg || DEFAULTS.LG_RATIO
+          lg: ratios.lg || DEFAULTS.LG_RATIO,
+          xl: ratios.xl || DEFAULTS.XL_RATIO
         };
 
-  const sizerClassName = `u-sizer-sm-${ratios.sm} u-sizer-md-${ratios.md} u-sizer-lg-${ratios.lg}`;
+  const sizerClassName = `u-sizer-sm-${ratios.sm} u-sizer-md-${ratios.md} u-sizer-lg-${ratios.lg} u-sizer-xl-${
+    ratios.xl
+  }`;
 
   const imageURL = ensurePhase1Asset(src);
   const smImageURL = imageURL
@@ -61,12 +66,15 @@ function Picture({
   const mdImageURL = imageURL
     .replace(RATIO_PATTERN, ratios.md)
     .replace(P1_RATIO_SIZE_PATTERN, `$1-${SIZES[ratios.md].md}`);
+  const lansdcapeLtLgImageURL = imageURL
+    .replace(RATIO_PATTERN, ratios.lg)
+    .replace(P1_RATIO_SIZE_PATTERN, `$1-${SIZES[ratios.lg].md}`);
   const lgImageURL = imageURL
     .replace(RATIO_PATTERN, ratios.lg)
     .replace(P1_RATIO_SIZE_PATTERN, `$1-${SIZES[ratios.lg].lg}`);
-  const lansdcapeNotLgImageURL = imageURL
-    .replace(RATIO_PATTERN, ratios.lg)
-    .replace(P1_RATIO_SIZE_PATTERN, `$1-${SIZES[ratios.lg].md}`);
+  const xlImageURL = imageURL
+    .replace(RATIO_PATTERN, ratios.xl)
+    .replace(P1_RATIO_SIZE_PATTERN, `$1-${SIZES[ratios.xl].xl}`);
 
   const placeholderEl = html`
     <div class="${sizerClassName}"></div>
@@ -74,8 +82,9 @@ function Picture({
 
   const picturePictureEl = html`
     <picture>
+      <source srcset="${xlImageURL}" media="${MQ.XL}" />
       <source srcset="${lgImageURL}" media="${MQ.LG}" />
-      <source srcset="${lansdcapeNotLgImageURL}" media="${MQ.LANDSCAPE} and ${MQ.NOT_LG}" />
+      <source srcset="${lansdcapeLtLgImageURL}" media="${MQ.LANDSCAPE} and ${MQ.LT_LG}" />
       <source srcset="${mdImageURL}" media="${MQ.MD}" />
       <source srcset="${smImageURL}" media="${MQ.SM}" />
     </picture>

--- a/src/app/components/Picture/index.scss
+++ b/src/app/components/Picture/index.scss
@@ -28,7 +28,7 @@
     will-change: opacity;
   }
 
-  @media #{$mq-not-lg} {
+  @media #{$mq-lt-lg} {
     &.is-contained img {
       object-fit: contain;
     }

--- a/src/app/components/Quote/index.scss
+++ b/src/app/components/Quote/index.scss
@@ -55,7 +55,7 @@
 .Quote.is-pullquote {
   text-align: center;
 
-  @media #{$mq-not-sm} {
+  @media #{$mq-gt-sm} {
     .u-pull-left &,
     .u-pull-right &,
     &.u-pull-left,
@@ -94,7 +94,7 @@
       font-size: 1.75rem;
     }
 
-    @media #{$mq-lg} {
+    @media #{$mq-gt-md} {
       font-size: 1.875rem;
     }
   }
@@ -108,7 +108,7 @@
       font-size: 1.125rem;
     }
 
-    @media #{$mq-lg} {
+    @media #{$mq-gt-md} {
       font-size: 1.25rem;
     }
 

--- a/src/app/components/Recirculation/index.js
+++ b/src/app/components/Recirculation/index.js
@@ -11,7 +11,8 @@ require('./index.scss');
 const PICTURE_RATIOS = {
   sm: '16x9',
   md: '16x9',
-  lg: '16x9'
+  lg: '16x9',
+  xl: '16x9'
 };
 
 function Recirculation({ ids, pull }) {

--- a/src/app/components/Recirculation/index.scss
+++ b/src/app/components/Recirculation/index.scss
@@ -77,7 +77,7 @@
 .Recirculation-item:not(.is-missing) ~ .Recirculation-item:not(.is-missing) {
   margin-top: 1.5rem;
 
-  @media #{$mq-lg} {
+  @media #{$mq-gt-md} {
     margin-top: 2.25rem;
   }
 }

--- a/src/app/components/ShareLink/index.scss
+++ b/src/app/components/ShareLink/index.scss
@@ -81,7 +81,7 @@
 }
 
 .ShareLink--whatsapp {
-  @media #{$mq-not-sm} {
+  @media #{$mq-gt-sm} {
     display: none;
   }
 

--- a/src/app/components/VideoControls/index.scss
+++ b/src/app/components/VideoControls/index.scss
@@ -78,7 +78,7 @@
       }
     }
 
-    @media #{$mq-lg} {
+    @media #{$mq-gt-md} {
       .u-pull &,
       .u-full & {
         margin-top: $size-control * -1;

--- a/src/app/components/VideoPlayer/index.js
+++ b/src/app/components/VideoPlayer/index.js
@@ -36,7 +36,8 @@ function VideoPlayer({
   ratios = {
     sm: ratios.sm || DEFAULT_RATIO,
     md: ratios.md || DEFAULT_RATIO,
-    lg: ratios.lg || DEFAULT_RATIO
+    lg: ratios.lg || DEFAULT_RATIO,
+    xl: ratios.xl || DEFAULT_RATIO
   };
 
   if (isInvariablyAmbient) {
@@ -59,7 +60,7 @@ function VideoPlayer({
   }
 
   const placeholderEl = html`
-    <div class="u-sizer-sm-${ratios.sm} u-sizer-md-${ratios.md} u-sizer-lg-${ratios.lg}"></div>
+    <div class="u-sizer-sm-${ratios.sm} u-sizer-md-${ratios.md} u-sizer-lg-${ratios.lg} u-sizer-xl-${ratios.xl}"></div>
   `;
   const videoEl = html`
     <video preload="none" tabindex="-1" aria-label="${title}"></video>

--- a/src/app/components/VideoPlayer/index.scss
+++ b/src/app/components/VideoPlayer/index.scss
@@ -72,7 +72,7 @@
     max-width: none;
   }
 
-  @media #{$mq-not-lg} {
+  @media #{$mq-lt-lg} {
     &.is-contained video {
       background-size: contain;
       object-fit: contain;

--- a/src/app/components/WhatNext/index.js
+++ b/src/app/components/WhatNext/index.js
@@ -14,7 +14,8 @@ require('./index.scss');
 const PICTURE_RATIOS = {
   sm: '3x2',
   md: '3x2',
-  lg: '3x2'
+  lg: '3x2',
+  xl: '3x2'
 };
 
 function WhatNext({ stories }) {

--- a/src/app/components/YouTubePlayer/index.js
+++ b/src/app/components/YouTubePlayer/index.js
@@ -41,7 +41,8 @@ function YouTubePlayer({
   ratios = {
     sm: ratios.sm || DEFAULT_RATIO,
     md: ratios.md || DEFAULT_RATIO,
-    lg: ratios.lg || DEFAULT_RATIO
+    lg: ratios.lg || DEFAULT_RATIO,
+    xl: ratios.xl || DEFAULT_RATIO
   };
 
   if (isInvariablyAmbient) {
@@ -66,7 +67,7 @@ function YouTubePlayer({
   const id = nextId++;
   const posterURL = `https://img.youtube.com/vi/${videoId}/0.jpg`;
   const placeholderEl = html`
-    <div class="u-sizer-sm-${ratios.sm} u-sizer-md-${ratios.md} u-sizer-lg-${ratios.lg}"></div>
+    <div class="u-sizer-sm-${ratios.sm} u-sizer-md-${ratios.md} u-sizer-lg-${ratios.lg} u-sizer-xl-${ratios.xl}"></div>
   `;
   const posterEl = html`
     <img src="${posterURL}" />

--- a/src/app/components/YouTubePlayer/index.scss
+++ b/src/app/components/YouTubePlayer/index.scss
@@ -18,7 +18,7 @@
     pointer-events: none;
   }
 
-  @media #{$mq-lg} {
+  @media #{$mq-gt-md} {
     &:not(.is-contained) iframe {
       transform: translate(-50%, -50%);
       top: 50%;
@@ -42,7 +42,7 @@
     object-fit: cover;
   }
 
-  @media #{$mq-not-lg} {
+  @media #{$mq-lt-lg} {
     &.is-contained img {
       object-fit: contain;
     }

--- a/src/app/components/utilities/dropcap.scss
+++ b/src/app/components/utilities/dropcap.scss
@@ -8,7 +8,7 @@
   font-weight: bold;
   line-height: 0.78; // Gecko ignores this
 
-  @media #{$mq-not-sm} {
+  @media #{$mq-gt-sm} {
     padding-top: 0.5rem;
     font-size: 3.625rem;
     line-height: 0.74; // Gecko ignores this
@@ -19,8 +19,8 @@
   text-indent: 0;
 
   &::first-letter {
-    @media #{$mq-not-sm} {
-      margin-left: -.4em;
+    @media #{$mq-gt-sm} {
+      margin-left: -0.4em;
     }
   }
 }

--- a/src/app/components/utilities/full.scss
+++ b/src/app/components/utilities/full.scss
@@ -11,7 +11,7 @@
   width: 100vw;
   width: calc(100vw - var(--scrollbar-width, 0px));
 
-  @media #{$mq-lg} {
+  @media #{$mq-gt-md} {
     margin-top: 3rem;
     margin-bottom: 3rem;
   }
@@ -28,7 +28,7 @@
 [class*='u-richtext'] > .u-full:not(.Gallery) + a[name] + .u-full:not(.Gallery) {
   margin-top: -2rem;
 
-  @media #{$mq-lg} {
+  @media #{$mq-gt-md} {
     margin-top: -3rem;
   }
 }

--- a/src/app/components/utilities/layout.scss
+++ b/src/app/components/utilities/layout.scss
@@ -5,7 +5,7 @@
   margin-right: auto;
   width: $layout-fluid;
 
-  @media #{$mq-lg} {
+  @media #{$mq-gt-md} {
     width: $layout-fixed;
   }
 }
@@ -21,7 +21,7 @@
     width: cells(10);
   }
 
-  @media #{$mq-lg} {
+  @media #{$mq-gt-md} {
     padding-left: $layout-fixed-padding;
     padding-right: $layout-fixed-padding;
     width: cells(8);

--- a/src/app/components/utilities/pull.scss
+++ b/src/app/components/utilities/pull.scss
@@ -1,13 +1,13 @@
 @import '../../../constants';
 
 [class*='u-pull'] {
-  @media #{$mq-not-sm} {
+  @media #{$mq-gt-sm} {
     clear: both;
   }
 }
 
 .u-pull {
-  @media #{$mq-not-sm} {
+  @media #{$mq-gt-sm} {
     width: 100%;
   }
 }
@@ -17,19 +17,19 @@
     width: cells(8);
   }
 
-  @media #{$mq-lg} {
+  @media #{$mq-gt-md} {
     width: cells(6);
   }
 }
 
 .u-pull-out {
-  @media #{$mq-lg} {
+  @media #{$mq-gt-md} {
     width: cells(10);
   }
 }
 
 .u-pull-left {
-  @media #{$mq-not-sm} {
+  @media #{$mq-gt-sm} {
     clear: left;
     float: left;
     margin-right: ($layout-fixed-padding * 3) !important; // *
@@ -43,7 +43,7 @@
 }
 
 .u-pull-right {
-  @media #{$mq-not-sm} {
+  @media #{$mq-gt-sm} {
     clear: right;
     float: right;
     margin-left: ($layout-fixed-padding * 3) !important; // *

--- a/src/app/components/utilities/quote.scss
+++ b/src/app/components/utilities/quote.scss
@@ -1,7 +1,7 @@
 @import '../../../constants';
 
-@media #{$mq-not-sm} {
+@media #{$mq-gt-sm} {
   .u-quote {
-    text-indent: -.4em;
+    text-indent: -0.4em;
   }
 }

--- a/src/app/components/utilities/richtext.scss
+++ b/src/app/components/utilities/richtext.scss
@@ -11,7 +11,7 @@
       margin-bottom: 2rem;
     }
 
-    @media #{$mq-lg} {
+    @media #{$mq-gt-md} {
       margin-bottom: 2.25rem;
     }
   }
@@ -34,7 +34,7 @@
       font-size: 2.25rem;
     }
 
-    @media #{$mq-lg} {
+    @media #{$mq-gt-md} {
       font-size: 3rem;
     }
   }
@@ -47,7 +47,7 @@
     font-size: 1.875rem;
     text-align: center;
 
-    @media #{$mq-not-sm} {
+    @media #{$mq-gt-sm} {
       font-size: 2.25rem;
     }
   }
@@ -72,7 +72,7 @@
     font-size: 1.125rem;
     line-height: 1.555555556;
 
-    @media #{$mq-not-sm} {
+    @media #{$mq-gt-sm} {
       line-height: 1.666666667;
     }
   }
@@ -98,7 +98,7 @@
     padding-left: calc(#{$layout-fluid-padding} + 0.85em);
     list-style-position: outside;
 
-    @media #{$mq-lg} {
+    @media #{$mq-gt-md} {
       padding-left: calc(#{$layout-fixed-padding} + 0.85em);
     }
   }
@@ -202,7 +202,7 @@
       margin-bottom: 1.666666667rem;
     }
 
-    @media #{$mq-lg} {
+    @media #{$mq-gt-md} {
       margin-bottom: 1.875rem;
     }
   }
@@ -222,7 +222,7 @@
       margin-bottom: 0.666666667rem;
     }
 
-    @media #{$mq-lg} {
+    @media #{$mq-gt-md} {
       margin-bottom: 0.75rem;
     }
   }

--- a/src/app/components/utilities/sizer.scss
+++ b/src/app/components/utilities/sizer.scss
@@ -75,7 +75,7 @@
   }
 }
 
-@media #{$mq-landscape} and #{$mq-not-lg}, #{$mq-lg} {
+@media #{$mq-lg}, #{$mq-landscape} and #{$mq-lt-lg} {
   .u-sizer-lg-16x9 {
     padding-top: 56.25%;
   }
@@ -93,6 +93,28 @@
   }
 
   .u-sizer-lg-3x4 {
+    padding-top: 133.3333333%;
+  }
+}
+
+@media #{$mq-xl} {
+  .u-sizer-xl-16x9 {
+    padding-top: 56.25%;
+  }
+
+  .u-sizer-xl-3x2 {
+    padding-top: 66.6666667%;
+  }
+
+  .u-sizer-xl-4x3 {
+    padding-top: 75%;
+  }
+
+  .u-sizer-xl-1x1 {
+    padding-top: 100%;
+  }
+
+  .u-sizer-xl-3x4 {
     padding-top: 133.3333333%;
   }
 }

--- a/src/app/meta/index.js
+++ b/src/app/meta/index.js
@@ -119,6 +119,8 @@ function getRelatedMedia() {
   const relatedMediaEl = $(`
     .view-hero-media,
     .content > article > header + figure,
+    .published + .inline-content.full.photo,
+    .published + .inline-content.full.video,
     .attached-content > .inline-content.photo,
     .attached-content > .inline-content.video
   `);

--- a/src/app/utils/misc.js
+++ b/src/app/utils/misc.js
@@ -1,5 +1,12 @@
 const smartquotes = require('./smartquotes');
-const { HYPHEN, NEWLINE, SM_RATIO_PATTERN, MD_RATIO_PATTERN, LG_RATIO_PATTERN } = require('../../constants');
+const {
+  HYPHEN,
+  NEWLINE,
+  SM_RATIO_PATTERN,
+  MD_RATIO_PATTERN,
+  LG_RATIO_PATTERN,
+  XL_RATIO_PATTERN
+} = require('../../constants');
 
 const SLUG_ALLOWED_PATTERN = /[^\w\s\-\_]/g;
 const SLUG_REPLACE_PATTERN = /[-\s]+/g;
@@ -45,8 +52,9 @@ function getRatios(str) {
   const [, sm] = str.match(SM_RATIO_PATTERN) || [];
   const [, md] = str.match(MD_RATIO_PATTERN) || [];
   const [, lg] = str.match(LG_RATIO_PATTERN) || [];
+  const [, xl] = str.match(XL_RATIO_PATTERN) || [];
 
-  return { sm, md, lg };
+  return { sm, md, lg, xl };
 }
 
 function dePx(px) {

--- a/src/constants.js
+++ b/src/constants.js
@@ -6,6 +6,7 @@ const RATIO_PATTERN = /(\d+x\d+)/;
 const SM_RATIO_PATTERN = /sm(\d+x\d+)/;
 const MD_RATIO_PATTERN = /md(\d+x\d+)/;
 const LG_RATIO_PATTERN = /lg(\d+x\d+)/;
+const XL_RATIO_PATTERN = /xl(\d+x\d+)/;
 const VIDEO_MARKER_PATTERN = /(?:video|youtube)(\w+)/;
 const SCROLLPLAY_PCT_PATTERN = /scrollplay(\d+)/;
 
@@ -56,19 +57,21 @@ const MOCK_ELEMENT = Object.assign(
 );
 
 const REM = 16; // (px)
-const MQ = {
-  SM: '(max-width: 43.6875rem)',
-  MD: '(min-width: 43.75rem) and (max-width: 61.1875rem)',
-  LG: '(min-width: 61.25rem)',
-  XL: '(min-width: 112.5rem)',
-  NOT_SM: '(min-width: 43.75rem)',
-  NOT_MD: '(max-width: 43.6875rem), (min-width: 61.25rem)',
-  NOT_LG: '(max-width: 61.1875rem)',
-  NOT_XL: '(max-width: 112.4375rem)',
-  PORTRAIT: '(orientation: portrait)',
-  LANDSCAPE: '(orientation: landscape)',
-  GT_4_3: '(min-aspect-ratio: 4/3)'
-};
+const MQ = {};
+MQ.LT_MD = '(max-width: 43.6875rem)';
+MQ.GT_SM = '(min-width: 43.75rem)';
+MQ.LT_LG = '(max-width: 61.1875rem)';
+MQ.GT_MD = '(min-width: 61.25rem)';
+MQ.LT_XL = '(max-width: 112.4375rem)';
+MQ.GT_LG = '(min-width: 112.5rem)';
+MQ.SM = MQ.LT_MD;
+MQ.MD = `${MQ.GT_SM} and ${MQ.LT_LG}`;
+MQ.LG = `${MQ.GT_MD} and ${MQ.LT_XL}`;
+MQ.XL = MQ.GT_LG;
+MQ.PORTRAIT = '(orientation: portrait)';
+MQ.LANDSCAPE = '(orientation: landscape)';
+MQ.GT_4_3 = '(min-aspect-ratio: 4/3)';
+MQ.PL_SM = '(max-width: 33.9375em)';
 
 const SMALLEST_IMAGE = 'data:image/gif;base64,R0lGODlhAQABAAAAADs=';
 

--- a/src/constants.scss
+++ b/src/constants.scss
@@ -85,18 +85,19 @@ $layout-fixed-gutter: 1.75rem;
 $layout-fluid-padding: $layout-fluid-gutter / 2;
 $layout-fixed-padding: $layout-fixed-gutter / 2;
 
-$mq-sm: '(max-width: 43.6875rem)';
-$mq-md: '(min-width: 43.75rem) and (max-width: 61.1875rem)';
-$mq-lg: '(min-width: 61.25rem)';
-$mq-xl: '(min-width: 112.5rem)';
-$mq-not-sm: '(min-width: 43.75rem)';
-$mq-not-md: '(max-width: 43.6875rem), (min-width: 61.25rem)';
-$mq-not-lg: '(max-width: 61.1875rem)';
-$mq-not-xl: '(max-width: 112.4375rem)';
+$mq-lt-md: '(max-width: 43.6875rem)';
+$mq-gt-sm: '(min-width: 43.75rem)';
+$mq-lt-lg: '(max-width: 61.1875rem)';
+$mq-gt-md: '(min-width: 61.25rem)';
+$mq-lt-xl: '(max-width: 112.4375rem)';
+$mq-gt-lg: '(min-width: 112.5rem)';
+$mq-sm: $mq-lt-md;
+$mq-md: '#{$mq-gt-sm} and #{$mq-lt-lg}';
+$mq-lg: '#{$mq-gt-md} and #{$mq-lt-xl}';
+$mq-xl: $mq-gt-lg;
 $mq-portrait: '(orientation: portrait)';
 $mq-landscape: '(orientation: landscape)';
 $mq-gt-4-3: '(min-aspect-ratio: 4/3)';
-
 $mq-pl-sm: '(max-width: 33.9375em)';
 
 $size-control: 2.5rem;


### PR DESCRIPTION
This PR adds another breakpoint for extra large displays (1800px+), allowing us to target styles and asset fetching for those displays.
This required us breaking down existing usage of the current 'large' breakpoint as into 'large' and 'greater than medium' (for those styles that still want to target 'extra large').
The Picture component now has an extra source defined for XL devices (using the same binaries as L for now).
Config hashtags and components with media can now use an xl*x* to denote specific aspect ratios to use at the new breakpoint, but sensible defaults exist.
The first major usage of the new breakpoint is the abreast Header variant, which still shows a 3:4 image on the L breakpoint, but now swaps out a 1:1 image on XL. You'll be able to see that in use on the current Pell lead story.

