### PR TITLE
Replace C(G)API with Terminus's content APIs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -443,9 +443,9 @@
 			"integrity": "sha512-wsgwwQtpniXRjuHKq5/7CX0k6WWTNI4qe5SIaG54l8sIJlIX/YBhelHHE/KCXfFYu59Q6EMqv6XDIu0P7IeyiQ=="
 		},
 		"@abcnews/terminus-fetch": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@abcnews/terminus-fetch/-/terminus-fetch-1.1.0.tgz",
-			"integrity": "sha512-dfBSXK+zKz2hBptDh7IbLNwsep1xRp1AF3M9YEWARYj69NRZOF3754+k8oboIbc0vtLX9uiDgr/5YLeHjpv7VA=="
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@abcnews/terminus-fetch/-/terminus-fetch-1.2.1.tgz",
+			"integrity": "sha512-aQ41//whmz8mfc0TkDqzH+ORuiy70QYmEiOzFy6he4cVIhyIgv0qtlQL9F4wAwHTPXW8Xo1L2Ch1eOb6GjKeJw=="
 		},
 		"@abcnews/url2cmid": {
 			"version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -432,11 +432,6 @@
 				"yeoman-generator": "^3.1.1"
 			}
 		},
-		"@abcnews/capi-fetch": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@abcnews/capi-fetch/-/capi-fetch-1.3.0.tgz",
-			"integrity": "sha512-uJF74S/srSJ99aMLBzzHFOr8pbffOOoNXsuvMY2VPqNezTLdHL9m9f1frqG9vaO9jW2s2yVE2pClAZ3eVMkVSg=="
-		},
 		"@abcnews/err": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@abcnews/err/-/err-1.0.1.tgz",
@@ -446,6 +441,11 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/@abcnews/poll-counters-client/-/poll-counters-client-1.3.1.tgz",
 			"integrity": "sha512-wsgwwQtpniXRjuHKq5/7CX0k6WWTNI4qe5SIaG54l8sIJlIX/YBhelHHE/KCXfFYu59Q6EMqv6XDIu0P7IeyiQ=="
+		},
+		"@abcnews/terminus-fetch": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@abcnews/terminus-fetch/-/terminus-fetch-1.1.0.tgz",
+			"integrity": "sha512-dfBSXK+zKz2hBptDh7IbLNwsep1xRp1AF3M9YEWARYj69NRZOF3754+k8oboIbc0vtLX9uiDgr/5YLeHjpv7VA=="
 		},
 		"@abcnews/url2cmid": {
 			"version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,49 +1,49 @@
 {
-	"name": "odyssey",
-	"version": "4.15.5",
-	"description": "Enhance feature-worthy stories",
-	"license": "MIT",
-	"private": true,
-	"contributors": [
-		"Simon Elvery <Elvery.Simon@abc.net.au>",
-		"Colin Gourlay <Gourlay.Colin@abc.net.au>",
-		"Nathan Hoad <Hoad.Nathan@abc.net.au>"
-	],
-	"scripts": {
-		"start": "aunty serve"
-	},
-	"dependencies": {
-		"@abcaustralia/abc-components": "^4.6.0",
-		"@abcaustralia/dls-components": "^11.7.0",
-		"@abcaustralia/profiles": "^5.0.1",
-		"@abcnews/capi-fetch": "^1.3.0",
-		"@abcnews/poll-counters-client": "^1.3.1",
-		"bel": "^6.0.0",
-		"classnames": "^2.2.6",
-		"core-js": "^3.1.2",
-		"custom-event-polyfill": "^1.0.7",
-		"date-fns": "^1.30.1",
-		"debounce": "^1.2.0",
-		"objectFitPolyfill": "^2.2.0",
-		"picturefill": "^3.0.3",
-		"react": "^16.8.6",
-		"react-dom": "^16.8.6",
-		"ric": "^1.3.0",
-		"util-dewysiwyg": "git+ssh://git@stash.abc-dev.net.au:7999/news/util-dewysiwyg.git#3.8.0",
-		"util-url2cmid": "git+ssh://git@stash.abc-dev.net.au:7999/news/util-url2cmid.git#1.0.1"
-	},
-	"devDependencies": {
-		"@abcaustralia/postcss-config": "^3.3.2",
-		"@abcnews/aunty": "^10.5.0",
-		"duplicate-package-checker-webpack-plugin": "^3.0.0",
-		"postcss-loader": "^3.0.0",
-		"webpack-bundle-analyzer": "^3.3.2"
-	},
-	"abc": {
-		"css": {
-			"libraryDir": "./node_modules/@abcaustralia/dls-components/css",
-			"brand": "news",
-			"logVariables": "false"
-		}
-	}
+  "name": "odyssey",
+  "version": "4.15.5",
+  "description": "Enhance feature-worthy stories",
+  "license": "MIT",
+  "private": true,
+  "contributors": [
+    "Simon Elvery <Elvery.Simon@abc.net.au>",
+    "Colin Gourlay <Gourlay.Colin@abc.net.au>",
+    "Nathan Hoad <Hoad.Nathan@abc.net.au>"
+  ],
+  "scripts": {
+    "start": "aunty serve"
+  },
+  "dependencies": {
+    "@abcaustralia/abc-components": "^4.6.0",
+    "@abcaustralia/dls-components": "^11.7.0",
+    "@abcaustralia/profiles": "^5.0.1",
+    "@abcnews/poll-counters-client": "^1.3.1",
+    "@abcnews/terminus-fetch": "^1.1.0",
+    "bel": "^6.0.0",
+    "classnames": "^2.2.6",
+    "core-js": "^3.1.2",
+    "custom-event-polyfill": "^1.0.7",
+    "date-fns": "^1.30.1",
+    "debounce": "^1.2.0",
+    "objectFitPolyfill": "^2.2.0",
+    "picturefill": "^3.0.3",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6",
+    "ric": "^1.3.0",
+    "util-dewysiwyg": "git+ssh://git@stash.abc-dev.net.au:7999/news/util-dewysiwyg.git#3.8.0",
+    "util-url2cmid": "git+ssh://git@stash.abc-dev.net.au:7999/news/util-url2cmid.git#1.0.1"
+  },
+  "devDependencies": {
+    "@abcaustralia/postcss-config": "^3.3.2",
+    "@abcnews/aunty": "^10.5.0",
+    "duplicate-package-checker-webpack-plugin": "^3.0.0",
+    "postcss-loader": "^3.0.0",
+    "webpack-bundle-analyzer": "^3.3.2"
+  },
+  "abc": {
+    "css": {
+      "libraryDir": "./node_modules/@abcaustralia/dls-components/css",
+      "brand": "news",
+      "logVariables": "false"
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@abcaustralia/dls-components": "^11.7.0",
     "@abcaustralia/profiles": "^5.0.1",
     "@abcnews/poll-counters-client": "^1.3.1",
-    "@abcnews/terminus-fetch": "^1.1.0",
+    "@abcnews/terminus-fetch": "^1.2.1",
     "bel": "^6.0.0",
     "classnames": "^2.2.6",
     "core-js": "^3.1.2",

--- a/src/app/components/GalleryEmbed/index.js
+++ b/src/app/components/GalleryEmbed/index.js
@@ -19,17 +19,6 @@ function GalleryEmbed({ galleryEl, captionEl, isAnon }) {
   `;
 }
 
-const terminusPromise = options =>
-  new Promise((resolve, reject) =>
-    terminusFetch(options, (err, result) => {
-      if (err) {
-        return reject(err);
-      }
-
-      resolve(result);
-    })
-  );
-
 function transformEl(el) {
   const linkEls = $$('a', el);
   const galleryId = url2cmid(linkEls[linkEls.length - 1].getAttribute('href'));
@@ -52,7 +41,7 @@ function transformEl(el) {
     mosaicRowLengths: mosaicRowLengthsString.split('')
   };
 
-  terminusPromise({ id: galleryId, type: 'gallery' }).then(galleryDoc => {
+  terminusFetch({ id: galleryId, type: 'gallery' }).then(galleryDoc => {
     // Mosaics should have a master caption
     if (config.mosaicRowLengths.length > 0) {
       config.masterCaptionEl = Caption.createFromEl(
@@ -71,7 +60,7 @@ function transformEl(el) {
     }
 
     Promise.all(
-      galleryDoc._embedded.content.map(item => terminusPromise({ id: item.id, type: item.docType.toLowerCase() }))
+      galleryDoc._embedded.content.map(item => terminusFetch({ id: item.id, type: item.docType.toLowerCase() }))
     ).then(imageDocs => {
       config.items = imageDocs.map(imageDoc => {
         const src = imageDoc.media.image.primary.complete[0].url;

--- a/src/app/components/Header/index.js
+++ b/src/app/components/Header/index.js
@@ -1,5 +1,5 @@
 // External
-const capiFetch = require('@abcnews/capi-fetch').default;
+const terminusFetch = require('@abcnews/terminus-fetch').default;
 const cn = require('classnames');
 const html = require('bel');
 const url2cmid = require('util-url2cmid');
@@ -211,7 +211,7 @@ function fetchInfoSourceLogo(meta, el, variant) {
     return;
   }
 
-  capiFetch(meta.infoSourceLogosDataId, (err, item) => {
+  terminusFetch({ id: meta.infoSourceLogosDataId, type: 'htmlfragment' }, (err, item) => {
     if (err) {
       return;
     }
@@ -220,8 +220,8 @@ function fetchInfoSourceLogo(meta, el, variant) {
     const logoDoc = logoDocs[`${meta.infoSource.name} (${variant})`] || logoDocs[meta.infoSource.name];
 
     if (logoDoc) {
-      capiFetch(logoDoc.id, (err, item) => {
-        const image = item.media[0];
+      terminusFetch({ id: logoDoc.id, type: logoDoc.docType.toLowerCase() }, (err, item) => {
+        const image = item.media.image.primary.complete[0];
         el.className = `${el.className} has-logo`;
         // Assume image@2x, with height clamped between 50px and 75px
         el.style.height = `${Math.min(75, Math.max(50, Math.round(image.height / 2)))}px`;

--- a/src/app/components/Recirculation/index.js
+++ b/src/app/components/Recirculation/index.js
@@ -1,5 +1,5 @@
 // External
-const capiFetch = require('@abcnews/capi-fetch').default;
+const terminusFetch = require('@abcnews/terminus-fetch').default;
 const html = require('bel');
 
 // Ours
@@ -29,7 +29,7 @@ function Recirculation({ ids, pull }) {
 
   el.classList.add('has-children');
   ids.forEach((id, index) =>
-    capiFetch(id, (err, item) => {
+    terminusFetch(id, (err, item) => {
       if (err) {
         itemEl.classList.add('is-missing');
 
@@ -37,8 +37,8 @@ function Recirculation({ ids, pull }) {
       }
 
       const itemEl = itemEls[index];
-      const title = item.shortTeaserTitle || item.teaserTitle || item.title;
-      const teaserText = item.shortTeaserTextPlain || item.teaserTextPlain;
+      const title = item.titleAlt.md || item.titleAlt.lg || item.title;
+      const teaser = item.synopsisAlt.md || item.synopsisAlt.lg || item.synopsis;
 
       itemEl.appendChild(
         html`
@@ -46,15 +46,15 @@ function Recirculation({ ids, pull }) {
         `
       );
 
-      if (item.thumbnailLink) {
-        itemEl.appendChild(Picture({ src: item.thumbnailLink.media[0].url, ratios: PICTURE_RATIOS }));
+      if (item._embedded.mediaThumbnail) {
+        itemEl.appendChild(Picture({ src: item._embedded.mediaThumbnail.complete[0].url, ratios: PICTURE_RATIOS }));
         invalidateClient();
       }
 
-      if (item.textPlain.indexOf(teaserText) !== 0) {
+      if (JSON.stringify(item.text).indexOf(teaser) !== 0) {
         itemEl.appendChild(
           html`
-            <p>${teaserText}</p>
+            <p>${teaser}</p>
           `
         );
       }

--- a/src/app/components/Recirculation/index.js
+++ b/src/app/components/Recirculation/index.js
@@ -51,7 +51,7 @@ function Recirculation({ ids, pull }) {
         invalidateClient();
       }
 
-      if (JSON.stringify(item.text).indexOf(teaser) !== 0) {
+      if (JSON.stringify(item.text).indexOf(teaser) === -1) {
         itemEl.appendChild(
           html`
             <p>${teaser}</p>

--- a/src/app/components/WhatNext/index.js
+++ b/src/app/components/WhatNext/index.js
@@ -1,5 +1,5 @@
 // External
-const capiFetch = require('@abcnews/capi-fetch').default;
+const terminusFetch = require('@abcnews/terminus-fetch').default;
 const cn = require('classnames');
 const html = require('bel');
 const url2cmid = require('util-url2cmid');
@@ -39,8 +39,8 @@ function WhatNext({ stories }) {
       return;
     }
 
-    capiFetch(id, (err, item) => {
-      if (err || !item.thumbnailLink) {
+    terminusFetch(id, (err, item) => {
+      if (err || !item._embedded.mediaThumbnail) {
         return;
       }
 
@@ -51,7 +51,7 @@ function WhatNext({ stories }) {
         itemEls[index] = teasedItem;
       }
 
-      prepend(itemEls[index], Picture({ src: item.thumbnailLink.media[0].url, ratios: PICTURE_RATIOS }));
+      prepend(itemEls[index], Picture({ src: item._embedded.mediaThumbnail.complete[0].url, ratios: PICTURE_RATIOS }));
       invalidateClient();
     });
   });


### PR DESCRIPTION
* Replace [`@abcnews/capi-fetch`](https://github.com/abcnews/capi-fetch) with [`@abcnews/terminus-fetch`](https://github.com/abcnews/terminus-fetch), which does the same job but with different live/preview API endpoints, and uses News' API key
* Update document structure in usage across various components (notably our `VideoPlayer`)

Note: This removes the need for a separate ImageProxy document fetch for video player poster images, as everything we need is now on the Video document ✨