### PR TITLE
An effort to reduce magic number use in SCSS, with added bonuses

### DIFF
--- a/public/share.html
+++ b/public/share.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="initial-scale=1.0" />
     <meta name="description" content="Text" />
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=Object.assign%2CArray.from%2CPromise%2CArray.prototype.find%2CArray.prototype.includes"></script>
   </head>
   <body class="platform-mobile">
     <header>

--- a/src/app/components/Block/content.scss
+++ b/src/app/components/Block/content.scss
@@ -1,4 +1,5 @@
 @import '../../../constants';
+@import '../Main/variables.scss';
 
 .Block-content {
   display: flex;
@@ -53,10 +54,10 @@
   }
 
   .Header.is-floating + .Block > &:nth-child(2) {
-    margin-top: calc(100vh - #{$abc-nav-height});
+    margin-top: calc(100vh - var(--Main-offsetTop));
 
-    body.platform-app & {
-      margin-top: 100vh;
+    [ie11] & {
+      margin-top: calc(100vh - #{$var--Main-offsetTop});
     }
   }
 

--- a/src/app/components/Header/index.scss
+++ b/src/app/components/Header/index.scss
@@ -1,9 +1,11 @@
 @import '../../../constants';
+@import '../Main/variables.scss';
+@import './variables.scss';
 
-$header-content-peek: 5.5rem;
-$header-abreast-margin: 2.5rem;
+$abreastChildSpacing: 2.5rem;
 
 .Header {
+  --Header-contentPeek: #{$var--Header-contentPeek};
   overflow: hidden;
   position: relative;
   line-height: 1.5;
@@ -24,28 +26,20 @@ $header-abreast-margin: 2.5rem;
   &.is-layered {
     display: flex;
     flex-direction: column-reverse;
-    min-height: calc(100vh - #{$abc-nav-height});
+    min-height: calc(100vh - var(--Main-offsetTop));
 
-    @media #{$mq-pl-sm} {
-      min-height: calc(100vh - #{$abc-nav-height--mq-pl-sm});
-    }
-
-    body.platform-app & {
-      min-height: calc(100vh);
+    [ie11] & {
+      min-height: calc(100vh - #{$var--Main-offsetTop});
     }
   }
 
   &.is-floating {
     z-index: 2;
-    margin-bottom: calc(-100vh + #{$abc-nav-height}) !important;
+    margin-bottom: calc(-100vh + var(--Main-offsetTop)) !important;
     background-color: transparent;
 
-    @media #{$mq-pl-sm} {
-      margin-bottom: calc(-100vh + #{$abc-nav-height--mq-pl-sm}) !important;
-    }
-
-    body.platform-app & {
-      margin-bottom: calc(-100vh) !important;
+    [ie11] & {
+      margin-bottom: calc(-100vh + #{$var--Main-offsetTop}) !important;
     }
   }
 
@@ -56,7 +50,7 @@ $header-abreast-margin: 2.5rem;
       justify-content: center;
 
       > * {
-        margin: $header-abreast-margin;
+        margin: $abreastChildSpacing;
       }
     }
   }
@@ -76,17 +70,10 @@ $header-abreast-margin: 2.5rem;
   }
 
   :not(.is-layered) > & {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    max-height: calc(100vh - #{$abc-nav-height + $header-content-peek});
+    max-height: calc(100vh - var(--Main-offsetTop) - var(--Header-contentPeek));
 
-    @media #{$mq-pl-sm} {
-      max-height: calc(100vh - #{$abc-nav-height--mq-pl-sm + $header-content-peek});
-    }
-
-    body.platform-app & {
-      max-height: calc(100vh - #{$header-content-peek});
+    [ie11] & {
+      max-height: calc(100vh - #{$var--Main-offsetTop + $var--Header-contentPeek});
     }
   }
 
@@ -106,6 +93,10 @@ $header-abreast-margin: 2.5rem;
     display: none;
   }
 
+  & > .html-fragment {
+    margin: 0;
+  }
+
   &::after {
     content: '';
     position: absolute;
@@ -123,26 +114,17 @@ $header-abreast-margin: 2.5rem;
   @media #{$mq-gt-md} {
     .is-abreast > & {
       flex-grow: 1;
-      -ms-flex: 1 0 50%;
-      max-height: calc(100vh - #{$abc-nav-height + $header-content-peek + $header-abreast-margin * 2});
+      max-height: calc(100vh - var(--Main-offsetTop) - var(--Header-contentPeek) - #{$abreastChildSpacing * 2});
       // Enforce 3x4 aspect ratio
-      max-width: calc(75vh - #{$abc-nav-height + $header-content-peek + $header-abreast-margin * 2});
+      max-width: calc(75vh - var(--Main-offsetTop) - var(--Header-contentPeek) - #{$abreastChildSpacing * 2});
 
-      body.platform-app & {
-        max-height: calc(100vh - #{$header-content-peek + $header-abreast-margin * 2});
-        max-width: calc(75vh - #{$header-content-peek + $header-abreast-margin * 2});
+      [ie11] & {
+        max-height: calc(100vh - #{$var--Main-offsetTop + $var--Header-contentPeek + $abreastChildSpacing * 2});
+        max-width: calc(75vh - #{$var--Main-offsetTop + $var--Header-contentPeek + $abreastChildSpacing * 2});
       }
 
       &::after {
         content: none;
-      }
-    }
-
-    .is-abreast.has-content-taller-than-peek > & {
-      max-height: calc(100vh - #{$abc-nav-height + $header-abreast-margin * 2});
-
-      body.platform-app & {
-        max-height: calc(100vh - #{$header-abreast-margin * 2});
       }
     }
   }
@@ -150,22 +132,25 @@ $header-abreast-margin: 2.5rem;
   @media #{$mq-xl} {
     .is-abreast > & {
       flex-grow: 0;
-      -ms-flex: 0 0 50%;
       // Enforce 1x1 aspect ratio
-      width: calc(100vh - #{$abc-nav-height + $header-content-peek + $header-abreast-margin * 2});
+      width: calc(100vh - var(--Main-offsetTop) - var(--Header-contentPeek) - #{$abreastChildSpacing * 2});
       max-width: none;
 
-      body.platform-app & {
-        width: calc(100vh - #{$header-content-peek + $header-abreast-margin * 2});
+      [ie11] & {
+        width: calc(100vh - #{$var--Main-offsetTop + $var--Header-contentPeek + $abreastChildSpacing * 2});
       }
     }
+  }
+
+  & > .ScrollHint {
+    position: absolute;
   }
 }
 
 /* In Firefox, parallax headers aren't clipped properly */
 @supports (-moz-appearance: meterbar) {
   :not(.is-layered) > .Header-media [data-component='OdysseyParallax_App'] > * {
-    height: calc(100vh - #{$header-content-peek});
+    clip: rect(0, auto, calc(100vh - var(--Main-offsetTop) - var(--Header-contentPeek)), 0);
   }
 }
 

--- a/src/app/components/Header/variables.scss
+++ b/src/app/components/Header/variables.scss
@@ -1,0 +1,1 @@
+$var--Header-contentPeek: 9rem;

--- a/src/app/components/Main/index.js
+++ b/src/app/components/Main/index.js
@@ -3,6 +3,8 @@ const cn = require('classnames');
 const html = require('bel');
 
 // Ours
+const { $ } = require('../../utils/dom');
+const { enqueue, subscribe } = require('../../scheduler');
 require('./index.scss');
 
 module.exports = function Main(childNodes, meta) {
@@ -12,7 +14,25 @@ module.exports = function Main(childNodes, meta) {
     'has-caption-attributions': meta.hasCaptionAttributions
   });
 
-  return html`
+  const el = html`
     <main class="${className}">${childNodes}</main>
   `;
+
+  subscribe(client => (client.hasChanged ? updateOffsetTop(el) : null));
+  window.requestIdleCallback(() => updateOffsetTop(el));
+
+  return el;
 };
+
+function updateOffsetTop(mainEl) {
+  let previewContainerHeight = 0;
+  const previewContainerEl = $('.preview-container');
+
+  if (previewContainerEl) {
+    previewContainerHeight = previewContainerEl.getBoundingClientRect().height;
+  }
+
+  enqueue(() => {
+    mainEl.style.setProperty('--Main-offsetTop', Math.round(mainEl.offsetTop - previewContainerHeight) + 'px');
+  });
+}

--- a/src/app/components/Main/index.scss
+++ b/src/app/components/Main/index.scss
@@ -1,6 +1,8 @@
 @import '../../../constants';
+@import './variables';
 
 .Main {
+  --Main-offsetTop: #{$var--Main-offsetTop};
   display: block;
 
   *,

--- a/src/app/components/Main/variables.scss
+++ b/src/app/components/Main/variables.scss
@@ -1,0 +1,1 @@
+$var--Main-offsetTop: 4rem;

--- a/src/app/components/ScrollHint/index.scss
+++ b/src/app/components/ScrollHint/index.scss
@@ -1,4 +1,7 @@
 @import '../../../constants';
+@import '../Main/variables.scss';
+
+$offsetBottom: 3rem;
 
 @keyframes ScrollHintBounce {
   from {
@@ -19,20 +22,6 @@
   height: 3rem;
   transition: opacity 0.5s;
   cursor: pointer;
-
-  .Header & {
-    position: absolute;
-    top: calc(100vh - #{$abc-nav-height + 3rem});
-    bottom: auto;
-
-    @media #{$mq-pl-sm} {
-      top: calc(100vh - #{$abc-nav-height--mq-pl-sm + 3rem});
-    }
-
-    body.platform-app & {
-      top: calc(100vh - 3rem);
-    }
-  }
 
   &.leaving {
     opacity: 0;

--- a/src/app/reset/index.js
+++ b/src/app/reset/index.js
@@ -71,6 +71,12 @@ const P2_FLOAT = {
   REPLACEMENT: 'u-pull-$2'
 };
 
+function addIE11StyleHint() {
+  if ('-ms-scroll-limit' in document.documentElement.style && '-ms-ime-align' in document.documentElement.style) {
+    document.documentElement.setAttribute('ie11', '');
+  }
+}
+
 function resetMetaViewport() {
   let el = $('meta[name="viewport"]');
 
@@ -102,6 +108,9 @@ function promoteToMain(storyEl, meta) {
 }
 
 function reset(storyEl, meta) {
+  // Try to feature-detect IE11, and apply an attribute to the root element for fallback styles to target
+  addIE11StyleHint();
+
   // Update (or add) the meta viewport tag so that touch devices don't introduce a click delay
   resetMetaViewport();
 

--- a/src/constants.scss
+++ b/src/constants.scss
@@ -102,7 +102,3 @@ $mq-pl-sm: '(max-width: 33.9375em)';
 
 $size-control: 2.5rem;
 $size-control-margin: 0.1875rem;
-
-// Environment measurements
-$abc-nav-height: 4rem;
-$abc-nav-height--mq-pl-sm: 3rem;


### PR DESCRIPTION
* Improve determination of Header (and Header media) height, by using sensible defaults (which persist on IE11), and CSS Custom Properties to allow them to update, based on the viewport size and height of things that precede the Main component (like nav bars).
* This dynamic variable calculation means that we no longer need specific styles for the ABC app (because the nav isn't rendered and the Main component will correctly have offsetTop=0).
* The Header content 'peek' on non-layered Headers can now self-adjust it's height to the number of lines in the story title.
* ScrollHints now appear in a better location. inside Headers.
* A better fix is now in place for Header parallax components in Firefox.