### PR TITLE
Header and Block background colours are only set when they oppose the current mode

### DIFF
--- a/src/app/components/Block/index.scss
+++ b/src/app/components/Block/index.scss
@@ -12,12 +12,12 @@
     min-height: var(--vw-ratio-16x9);
   }
 
-  &.has-dark {
+  :root:not(.is-dark-mode) &.has-dark {
     background-color: $color-black;
   }
 
-  &.has-light {
-    background-color: $color-white;
+  :root.is-dark-mode &.has-light {
+    background-color: $color-grey-50;
   }
 }
 

--- a/src/app/components/Block/index.scss
+++ b/src/app/components/Block/index.scss
@@ -13,11 +13,11 @@
   }
 
   :root:not(.is-dark-mode) &.has-dark {
-    background-color: $color-black;
+    background-color: $color-darkBg;
   }
 
   :root.is-dark-mode &.has-light {
-    background-color: $color-grey-50;
+    background-color: $color-lightBg;
   }
 }
 

--- a/src/app/components/Comments/index.scss
+++ b/src/app/components/Comments/index.scss
@@ -4,7 +4,7 @@
   margin-bottom: 0 !important;
 
   .is-dark-mode & {
-    background-color: $color-white;
+    background-color: $color-lightBg;
   }
 }
 

--- a/src/app/components/Gallery/index.scss
+++ b/src/app/components/Gallery/index.scss
@@ -222,7 +222,7 @@
     max-width: calc(100% - 0.25rem);
     min-height: 0;
     background-color: $color-black-transparent-60;
-    color: $color-grey-50;
+    color: $color-lightBg;
     pointer-events: none;
     transition-delay: 0s;
 

--- a/src/app/components/Header/index.js
+++ b/src/app/components/Header/index.js
@@ -34,7 +34,7 @@ function Header({
 }) {
   isFloating = isFloating || (isLayered && !imgEl && !videoId && !interactiveEl);
   isLayered = isLayered || isFloating;
-  isDark = meta.isDarkMode || isLayered || isDark;
+  isDark = isLayered || typeof isDark === 'boolean' ? isDark : meta.isDarkMode;
   isAbreast = !isFloating && !isLayered && (imgEl || videoId || interactiveEl) && isAbreast;
 
   const className = cn(

--- a/src/app/components/Header/index.js
+++ b/src/app/components/Header/index.js
@@ -245,7 +245,7 @@ function transformSection(section, meta) {
   const ratios = getRatios(section.configSC);
   const isFloating = section.configSC.indexOf('floating') > -1;
   const isLayered = isFloating || section.configSC.indexOf('layered') > -1;
-  const isDark = isLayered || section.configSC.indexOf('dark') > -1;
+  const isDark = isLayered || (section.configSC.indexOf('dark') > -1 && section.configSC.indexOf('light') === -1);
   const isPale = section.configSC.indexOf('pale') > -1;
   const isAbreast = section.configSC.indexOf('abreast') > -1;
   const isNoMedia = isFloating || section.configSC.indexOf('nomedia') > -1;

--- a/src/app/components/Header/index.scss
+++ b/src/app/components/Header/index.scss
@@ -15,11 +15,11 @@ $abreastChildSpacing: 2.5rem;
   }
 
   :root.is-dark-mode &:not(.is-dark) {
-    background-color: $color-grey-50;
+    background-color: $color-lightBg;
   }
 
   :root:not(.is-dark-mode) &.is-dark {
-    background-color: $color-black;
+    background-color: $color-darkBg;
   }
 
   &.is-layered {
@@ -58,10 +58,10 @@ $abreastChildSpacing: 2.5rem;
 .Header-media {
   overflow: hidden;
   position: relative;
-  background-color: $color-black;
+  background-color: $color-darkBg;
 
   .is-pale > & {
-    background-color: $color-white;
+    background-color: $color-lightBg;
   }
 
   .is-abreast > & {

--- a/src/app/components/Header/index.scss
+++ b/src/app/components/Header/index.scss
@@ -9,18 +9,17 @@ $abreastChildSpacing: 2.5rem;
   overflow: hidden;
   position: relative;
   line-height: 1.5;
-  background-color: $color-grey-50;
 
   @media #{$mq-gt-sm} {
     font-size: 1.25rem;
   }
 
-  &.is-dark {
-    background-color: $color-black;
+  :root.is-dark-mode &:not(.is-dark) {
+    background-color: $color-grey-50;
   }
 
-  .is-dark-mode &:not(.is-dark) {
-    background-color: $color-grey-50;
+  :root:not(.is-dark-mode) &.is-dark {
+    background-color: $color-black;
   }
 
   &.is-layered {

--- a/src/app/components/Sizer/index.scss
+++ b/src/app/components/Sizer/index.scss
@@ -23,7 +23,7 @@
     .Header.is-layered &,
     .Block &,
     .MasterGallery & {
-      background-color: $color-black;
+      background-color: $color-darkBg;
     }
   }
 

--- a/src/app/components/VideoPlayer/index.scss
+++ b/src/app/components/VideoPlayer/index.scss
@@ -10,7 +10,7 @@
   user-select: none;
   -webkit-user-drag: none;
   user-drag: none;
-  background-color: $color-black;
+  background-color: $color-darkBg;
 
   .u-full > & {
     height: 100%;

--- a/src/app/components/YouTubePlayer/index.scss
+++ b/src/app/components/YouTubePlayer/index.scss
@@ -3,7 +3,7 @@
 .YouTubePlayer {
   position: relative;
   overflow: hidden;
-  background-color: $color-black;
+  background-color: $color-darkBg;
 
   .u-full > & {
     height: 100%;

--- a/src/app/components/utilities/blend-luminosity.scss
+++ b/src/app/components/utilities/blend-luminosity.scss
@@ -4,7 +4,7 @@
   .u-blend-luminosity {
     background-blend-mode: luminosity;
     background-color: $color-grey-50 !important;
-    background-color: var(--bg, #{$color-grey-50}) !important;
+    background-color: var(--bg, #{$color-lightBg}) !important;
     background-image: linear-gradient($color-grey-200-transparent-30, $color-grey-200-transparent-30);
 
     .u-richtext-invert & {

--- a/src/app/components/utilities/blend-luminosity.scss
+++ b/src/app/components/utilities/blend-luminosity.scss
@@ -3,13 +3,13 @@
 @supports (background-blend-mode: luminosity) {
   .u-blend-luminosity {
     background-blend-mode: luminosity;
-    background-color: $color-grey-50 !important;
+    background-color: $color-lightBg !important;
     background-color: var(--bg, #{$color-lightBg}) !important;
     background-image: linear-gradient($color-grey-200-transparent-30, $color-grey-200-transparent-30);
 
     .u-richtext-invert & {
-      background-color: $color-black !important;
-      background-color: var(--bg, #{$color-black}) !important;
+      background-color: $color-darkBg !important;
+      background-color: var(--bg, #{$color-darkBg}) !important;
       background-image: linear-gradient($color-grey-500-transparent-65, $color-grey-500-transparent-65);
     }
   }

--- a/src/app/components/utilities/richtext.scss
+++ b/src/app/components/utilities/richtext.scss
@@ -268,7 +268,7 @@
   > ol li,
   > blockquote,
   > table {
-    color: $color-grey-50;
+    color: $color-lightBg;
   }
 
   > ul > li,

--- a/src/app/reset/index.scss
+++ b/src/app/reset/index.scss
@@ -28,12 +28,12 @@ body {
   min-width: 0; /* Override Phase 1 (Standard)'s 1000px */
   min-height: 102vh;
   width: 100%;
-  background-color: $color-grey-50;
-  background-color: var(--bg, #{$color-grey-50});
+  background-color: $color-lightBg;
+  background-color: var(--bg, #{$color-lightBg});
 
-  .is-dark-mode > & {
-    background-color: $color-black;
-    background-color: var(--bg, #{$color-black});
+  :root.is-dark-mode > & {
+    background-color: $color-darkBg;
+    background-color: var(--bg, #{$color-darkBg});
   }
 
   /* Remove margin & padding applied by preview tools */
@@ -79,7 +79,7 @@ body {
   }
 
   main + .page_margins {
-    background-color: $color-grey-50;
+    background-color: $color-lightBg;
   }
 
   main + .content {

--- a/src/constants.scss
+++ b/src/constants.scss
@@ -19,7 +19,6 @@ $color-black-transparent-60: rgba(0, 0, 0, 0.6);
 $color-black-transparent-75: rgba(0, 0, 0, 0.75);
 $color-black-transparent-93: rgba(0, 0, 0, 0.93);
 
-$color-grey-50: #f9f9f9;
 $color-grey-100: #d2d2d2;
 $color-grey-200-transparent-30: rgba(196, 196, 196, 0.3);
 $color-grey-300: #b3b3b3;
@@ -28,6 +27,9 @@ $color-grey-300-transparent-70: rgba(179, 179, 179, 0.7);
 $color-grey-500: #666;
 $color-grey-500-transparent-65: rgba(102, 102, 102, 0.65);
 $color-grey-900: #111;
+
+$color-lightBg: #f9f9f9;
+$color-darkBg: $color-black;
 
 $color-lighterPrimary: #a5daf3;
 $color-lightPrimary: #68e1ff;


### PR DESCRIPTION
`Header` and `Block` components now only explicitly set a background colour if they oppose the current mode. For example, if `dark-mode` is not enabled, a `Header`'s background will now effectively be transparent, because it can depend on the underlying document background colour. This way, when we set a theme background colour, those components will now share it.

We used to hack this feature into stories such as @drzax's crypto explainer and the upcoming happiness and unpaid labour stories. DSI and CPH have also had to hack it in too, and it's pretty obvious at this point that this should be Odyssey's default behaviour.

Previously, there was no way to define a light header on a dark mode document. Now, you can put `light` in the opening header tag to define this. Dark mode used to always enforce a dark Header, but Headers now only defer to the mode if `dark`/`light` isn't explicitly defined on the opening `#header` tag. 

The SCSS variables have also had a tiny refactor, to make it more obvious where we're using light/dark background colours on components, either to conform to the current mode, or subvert it.