### PR TITLE
Quotes in Galleries

### DIFF
--- a/src/app/components/Gallery/index.scss
+++ b/src/app/components/Gallery/index.scss
@@ -124,6 +124,7 @@
 
   .Gallery:not(.is-mosaic) & {
     flex: 0 0 100% !important;
+    max-width: none !important;
 
     &:focus {
       outline: 0;

--- a/src/app/components/Gallery/index.scss
+++ b/src/app/components/Gallery/index.scss
@@ -250,6 +250,28 @@
   }
 }
 
+.Gallery-richtextTile {
+  position: relative;
+}
+
+.Gallery-richtextTileContent {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+
+  & > * {
+    margin: 0.5rem 1rem !important;
+    padding: 0 !important;
+    max-width: 40rem !important;
+  }
+}
+
 .Gallery-controls {
   display: flex;
   justify-content: space-between;

--- a/src/app/components/Quote/index.js
+++ b/src/app/components/Quote/index.js
@@ -18,30 +18,30 @@ function Quote({ isPullquote = false, alignment, parEls = [], attributionNodes =
   const attributionEl = attributionNodes.length
     ? html`
         <footer>
-          ${
-            Array.from(attributionNodes).map(node => {
-              return node.tagName === 'A'
-                ? html`
-                    <cite>${node}</cite>
-                  `
-                : node;
-            })
-          }
+          ${Array.from(attributionNodes).map(node => {
+            return node.tagName === 'A'
+              ? html`
+                  <cite>${node}</cite>
+                `
+              : node;
+          })}
         </footer>
       `
     : null;
 
   // Smart double quotes & indentation
   if (parEls.length) {
-    parEls.forEach(UQuote.conditionallyApply);
+    parEls.forEach(parEl => UQuote.conditionallyApply(parEl, isPullquote));
   }
 
   return html`
-    <div class="${className}"><blockquote>${parEls.concat(attributionEl)}</blockquote></div>
+    <div class="${className}">
+      <blockquote>${parEls.concat(attributionEl)}</blockquote>
+    </div>
   `;
 }
 
-function createFromEl(el) {
+function createFromEl(el, options) {
   if (!isElement(el)) {
     return null;
   }
@@ -137,14 +137,14 @@ function createFromEl(el) {
   }, []);
 
   if (config) {
-    return Quote(config);
+    return Quote({ ...config, ...(typeof options === 'object' ? options : {}) });
   }
 
   return null;
 }
 
-function transformEl(el) {
-  substitute(el, createFromEl(el));
+function transformEl(el, options) {
+  substitute(el, createFromEl(el, options));
 }
 
 function isBr(node) {

--- a/src/app/components/Sizer/index.js
+++ b/src/app/components/Sizer/index.js
@@ -45,6 +45,7 @@ function updateHeightSnapping() {
     instances.forEach(el => {
       const { width, height } = el.getBoundingClientRect();
       const snappedHeight = Math.round(height);
+      console.log(el, height, snappedHeight);
 
       if (height !== snappedHeight) {
         el.style.setProperty('padding-top', `${snappedHeight}px`);

--- a/src/app/components/Sizer/index.js
+++ b/src/app/components/Sizer/index.js
@@ -45,7 +45,6 @@ function updateHeightSnapping() {
     instances.forEach(el => {
       const { width, height } = el.getBoundingClientRect();
       const snappedHeight = Math.round(height);
-      console.log(el, height, snappedHeight);
 
       if (height !== snappedHeight) {
         el.style.setProperty('padding-top', `${snappedHeight}px`);

--- a/src/app/components/UQuote/index.js
+++ b/src/app/components/UQuote/index.js
@@ -3,10 +3,10 @@ const { smartquotes } = require('../../utils/misc');
 
 const BEGINS_WITH_LEFT_DOUBLE_QUOTATION_MARK_PATTERN = /^\u201c/;
 
-function conditionallyApply(el) {
+function conditionallyApply(el, isPullquote) {
   smartquotes(el);
 
-  if (el.tagName === 'P' && BEGINS_WITH_LEFT_DOUBLE_QUOTATION_MARK_PATTERN.test(el.textContent)) {
+  if (!isPullquote && el.tagName === 'P' && BEGINS_WITH_LEFT_DOUBLE_QUOTATION_MARK_PATTERN.test(el.textContent)) {
     el.classList.add('u-quote');
   }
 }

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -32,7 +32,6 @@ const { getMeta } = require('./meta');
 const { reset } = require('./reset');
 const { getMarkers, getSections } = require('./utils/anchors');
 const { $, $$, after, append, detach, detachAll, prepend, substitute } = require('./utils/dom');
-const { literalList } = require('./utils/misc');
 
 function app() {
   const meta = getMeta();
@@ -169,18 +168,10 @@ function app() {
       ImageEmbed.transformEl(el, isSidePulled);
     });
 
-  // Transform quotes (native and embedded)
-  $$(
-    literalList(`
-      blockquote:not([class])
-      .quote--pullquote
-      .inline-content.quote
-      .embed-quote
-      .comp-rich-text-blockquote
-      .view-inline-pullquote
-    `),
-    storyEl
-  ).forEach(Quote.transformEl);
+  // Transform quotes (native and embedded) that haven't already been transformed
+  $$(SELECTORS.QUOTE, storyEl)
+    .filter(el => el.closest('.Quote') === null)
+    .forEach(Quote.transformEl);
 
   // Nullify nested pulls (outer always wins)
   $$('[class*="u-pull"] [class*="u-pull"]').forEach(

--- a/src/constants.js
+++ b/src/constants.js
@@ -20,7 +20,9 @@ const SELECTORS = {
   BYLINE: '.view-byline,header>.attribution,.byline',
   INFO_SOURCE: '.bylinepromo,.program',
   INFO_SOURCE_LINK: '.bylinepromo>a,.program>a',
-  WYSIWYG_EMBED: '.inline-content.wysiwyg,.embed-wysiwyg.richtext,.view-wysiwyg'
+  WYSIWYG_EMBED: '.inline-content.wysiwyg,.embed-wysiwyg.richtext,.view-wysiwyg',
+  QUOTE:
+    'blockquote:not([class]),.quote--pullquote,.inline-content.quote,.embed-quote,.comp-rich-text-blockquote,.view-inline-pullquote'
 };
 
 const RICHTEXT_BLOCK_TAGNAMES = ['P', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'OL', 'UL'];

--- a/src/polyfills/index.js
+++ b/src/polyfills/index.js
@@ -6,3 +6,19 @@ require('custom-event-polyfill');
 require('ric');
 // CSS
 require('objectFitPolyfill');
+
+if (!Element.prototype.matches) {
+  Element.prototype.matches = Element.prototype.msMatchesSelector || Element.prototype.webkitMatchesSelector;
+}
+
+if (!Element.prototype.closest) {
+  Element.prototype.closest = function(s) {
+    var el = this;
+
+    do {
+      if (el.matches(s)) return el;
+      el = el.parentElement || el.parentNode;
+    } while (el !== null && el.nodeType === 1);
+    return null;
+  };
+}


### PR DESCRIPTION
Pull-quotes in #gallery/#mosaic sections will now be included as items in their respective Gallery/Mosaic components, horizontally and vertically centred within fixed size tiles.

This opens up the option of having a swipable gallery of quotes, or a mosaic that combines photos/videos/quotes in visually interesting ways.

The only difference between normal quotes and gallery item quotes is the limited canvas size (especially noticable on small devices with 2-3 items in a mosaic row, so we'll have to limit the amount of text in the quotes (and visually confirm it doesn't overflow).

