### PR TITLE
Add color-scheme CSS prop to Datawrapper iframes

### DIFF
--- a/src/app/index.js
+++ b/src/app/index.js
@@ -296,6 +296,7 @@ export default terminusDocument => {
 
     // Always remove the white background (set by PL's className)
     el.style.setProperty('background-color', 'transparent');
+    el.style.setProperty('color-scheme', shouldBeDark ? 'dark' : 'light');
 
     // Change the URL, if needed
     if (el.src !== desiredSrc) {


### PR DESCRIPTION
Ensure Datawrapper iframes are marked as supporting the same colour scheme as the theme of the chart being embedded.

After much trial and error, I think this will solve the issue of Datawrapper embeds with a dark theme getting an off-black background colour. I think this bug only shows up in Odysseys, so fixing it here *should* be all that's required.

To boil it down, this is what the browser does:
1. Calculates what mode each frame should be rendered with based on what it supports and what the user preference is.
2. If there's a mismatch between the calculated modes of the parent frame and iframe, the iframe gets a default browser background colour that matches the mode of the iframe content, otherwise it's transparent to let the parent's background colour bleed through.

This situation, where there's a mismatch, only occurs on Odysseys because we're forcing the mode of the Datawrapper embed.