### PR TITLE
add support for tiktok embeds, fix alignment bug for interactive embeds

### DIFF
--- a/src/app/components/InteractiveEmbed/index.js
+++ b/src/app/components/InteractiveEmbed/index.js
@@ -15,6 +15,7 @@ const SUPPORTED_PROVIDER_TYPES = [
   'soundcloud',
   'vimeo',
   'youtube',
+  'tiktok',
   'youtubeplaylist'
 ];
 const LOADERS_ENDPOINT = `https://${
@@ -26,7 +27,7 @@ const InteractiveEmbed = ({ url, providerType, alignment, isFull }) => {
   const isSupportedProviderType = SUPPORTED_PROVIDER_TYPES.indexOf(providerType) > -1;
 
   if (!isSupportedProviderType) {
-    return '<div></div>';
+    return document.createElement('div');
   }
 
   const hasAspectRatio = providerType === 'vimeo' || providerType.indexOf('youtube') === 0;
@@ -100,7 +101,7 @@ export const transformElement = el => {
   const url = el.getAttribute('itemid');
   const providerType = el.getAttribute('data-provider');
   const configString = grabPrecedingConfigString(el);
-  const descriptorAlignment = el._descriptor ? EMBED_ALIGNMENT_MAP[el._descriptor.props.align] : undefined;
+  const descriptorAlignment = el._descriptor ? EMBED_ALIGNMENT_MAP[el._descriptor.props.alignment] : undefined;
   const [, alignment] = configString.match(ALIGNMENT_PATTERN) || [, descriptorAlignment];
 
   substitute(

--- a/src/app/components/InteractiveEmbed/index.lazy.scss
+++ b/src/app/components/InteractiveEmbed/index.lazy.scss
@@ -24,6 +24,13 @@
   width: 100% !important;
 }
 
+.InteractiveEmbed[data-provider='tiktok'] blockquote.tiktok-embed {
+  max-width: 325px !important;
+  background-color: transparent;
+  border: 0;
+  padding: 0;
+}
+
 .InteractiveEmbed iframe {
   width: 100% !important;
 }


### PR DESCRIPTION
Add tiktok to the list of interactives that we support embedding in Odysseys. Nothing too controversial there I think.

This also fixes a bug where interactive embeds were not respecting embed left or right, which needs some QA to ensure old odysseys don't have wacky left and right embedding that was previously ignored
