### PR TITLE
Feature/tiktok interactive block media

### DIFF
--- a/src/app/components/Block/index.js
+++ b/src/app/components/Block/index.js
@@ -47,6 +47,7 @@ const Block = ({
   isGrouped,
   isLight,
   isPiecemeal,
+  isPhoneFrame,
   isVideoYouTube,
   ratios = {},
   shouldVideoPlayOnce,
@@ -168,9 +169,25 @@ const Block = ({
     }
   }
 
+  // Wrap in extra div to pop it in a phone frame
+  if (isPhoneFrame) {
+    // if (backgroundsEls && backgroundsEls.length) {
+    //   backgroundsEls = html`<div class="phone-frame">${backgroundsEls}</div>`;
+    // } else {
+    mediaEl = html`<div class="phone-frame">${mediaEl}</div>`;
+    // }
+  }
+
+  console.log(backgroundsEls);
+
   let mediaContainerEl;
   if (backgroundsEls && backgroundsEls.length) {
-    mediaContainerEl = html`<div class="${mediaClassName}">${backgroundsEls}</div>`;
+    if (isPhoneFrame) {
+      mediaContainerEl = html`<div class="${mediaClassName}"><div class="phone-frame">${backgroundsEls}</div></div>`;
+    } else {
+      mediaContainerEl = html`<div class="${mediaClassName}">${backgroundsEls}</div>`;
+    }
+
   } else {
     mediaContainerEl = mediaEl ? html`<div class="${mediaClassName}">${mediaEl}</div>` : null;
   }
@@ -190,6 +207,7 @@ const Block = ({
   const blockEl = html`
     <div class="${className}" style="${backgroundColourStyle}">
       ${mediaContainerEl}
+
       ${isPiecemeal
         ? contentEls.reduce((memo, contentEl) => {
             const piecemeallAlignment = contentEl.getAttribute('data-alignment');
@@ -340,6 +358,7 @@ export const transformSection = section => {
   const isGrouped = section.configString.indexOf('grouped') > -1;
   const isLight = section.configString.indexOf('light') > -1;
   const isPiecemeal = section.configString.indexOf('piecemeal') > -1;
+  const isPhoneFrame = section.configString.indexOf('phoneframe') > -1;
   const shouldSupplant = section.configString.indexOf('supplant') > -1;
   const shouldVideoPlayOnce = section.configString.indexOf('once') > -1;
   const [, videoScrollplayPctString] = section.configString.match(SCROLLPLAY_PCT_PATTERN) || [, ''];
@@ -388,6 +407,7 @@ export const transformSection = section => {
     isGrouped,
     isLight,
     isPiecemeal,
+    isPhoneFrame,
     shouldVideoPlayOnce,
     videoScrollplayPct,
     blockBackgroundColour

--- a/src/app/components/Block/index.js
+++ b/src/app/components/Block/index.js
@@ -345,8 +345,8 @@ export const transformSection = section => {
   const [, videoScrollplayPctString] = section.configString.match(SCROLLPLAY_PCT_PATTERN) || [, ''];
   const videoScrollplayPct =
     videoScrollplayPctString.length > 0 && Math.max(0, Math.min(100, +videoScrollplayPctString));
-  const [, blockBackgroundColourString] = section.configString.match(BLOCK_BACKGROUND_COLOUR_PATTERN) || [, '000000'];
-  const blockBackgroundColour = `#${blockBackgroundColourString}`;
+  const [, blockBackgroundColourString] = section.configString.match(BLOCK_BACKGROUND_COLOUR_PATTERN) || [, ''];
+  const blockBackgroundColour = blockBackgroundColourString ? `#${blockBackgroundColourString}` : '';
 
   let transition;
 

--- a/src/app/components/Block/index.js
+++ b/src/app/components/Block/index.js
@@ -257,27 +257,25 @@ const Block = ({
         return console.error('Expected to find an active marker during _checkIfBackgroundShouldChange');
       }
 
-      // get the last marker that has a bottom above the fold
-      const FIXED_HEIGHT_RATIO = 0.8;
-      const marker = markers.reduce((activeMarker, currentMarker) => {
-        const { top, bottom } = currentMarker.getBoundingClientRect();
+      let marker;
 
-        // If the item has already gone off the screen, this is not our thing
-        if (bottom < 0 - client.fixedHeight * FIXED_HEIGHT_RATIO) return activeMarker;
+      // If we're outside the block, don't load any background els.
+      const rect = blockEl.getBoundingClientRect();
+      const fixedHeight = client.fixedHeight;
+      const isScrolledAboveBlock = rect.y > fixedHeight;
+      const isScrolledBelowBlock = rect.bottom < 0;
 
-        // if the item is currently on the screen, this is our thing
-        if (!activeMarker && top - client.fixedHeight * FIXED_HEIGHT_RATIO < client.fixedHeight) {
+      if (!isScrolledAboveBlock && !isScrolledBelowBlock) {
+        // If we are inside the block, get the last marker that has a bottom above the fold
+        marker = markers.reduce((activeMarker, currentMarker) => {
+          const { top } = currentMarker.getBoundingClientRect();
+          if (top > fixedHeight * 0.8) return activeMarker;
+
           return currentMarker;
-        }
+        }, markers[0]);
+      }
 
-        // If the item hasn't appeared on screen yet, this is not our thing
-        if (top > client.fixedHeight * FIXED_HEIGHT_RATIO) return activeMarker;
-
-
-        return currentMarker;
-      }, null);
-
-      /** The index for the current item, or -1 if we're off the screen. */
+      /** The index for the current item, or -1 if we're outside the block. */
       const newActiveIndex = marker ? parseInt(marker.getAttribute('data-background-index'), 10) : -1;
 
       if (activeIndex !== newActiveIndex) {

--- a/src/app/components/Block/index.js
+++ b/src/app/components/Block/index.js
@@ -270,7 +270,7 @@ const Block = ({
           return currentMarker;
         }
 
-        // If the item hasn't appeart on screen yet, this is not our thing
+        // If the item hasn't appeared on screen yet, this is not our thing
         if (top > client.fixedHeight * FIXED_HEIGHT_RATIO) return activeMarker;
 
 

--- a/src/app/components/Block/index.js
+++ b/src/app/components/Block/index.js
@@ -178,8 +178,6 @@ const Block = ({
     // }
   }
 
-  console.log(backgroundsEls);
-
   let mediaContainerEl;
   if (backgroundsEls && backgroundsEls.length) {
     if (isPhoneFrame) {
@@ -513,7 +511,7 @@ export const transformSection = section => {
 
           // Add a non-caption, to keep the background:caption indices in sync
           if (hasAttributedMedia || hasCaptionedMedia) {
-            config.captionEls.push(null);
+            config.captionEls.push(createCaptionFromElement(node, true));
           }
 
           return null;

--- a/src/app/components/Block/media.scss
+++ b/src/app/components/Block/media.scss
@@ -53,7 +53,7 @@
     height: 100%;
     max-height: 85vh;
 
-    filter: drop-shadow(2px 4px 6px gold);
+    filter: drop-shadow(2px 4px 6px white);
 
     @media #{$mq-gt-md} {
       width: $unit * 33;
@@ -65,14 +65,15 @@
       position: fixed;
       max-width: 395px !important;
       max-height: 85vh;
-      background-color: transparent;
+      width: 100%;
+      aspect-ratio: 9 / 16;
+
+      top: calc(50% - 361px);
       border: 0;
       padding: 0;
       margin: auto;
 
-      top: calc(50% - 361px);
-      height: 100%;
-      width: 100%;
+      background-color: transparent;
 
       // Horizontally center unless on large screen
       left: 50%;

--- a/src/app/components/Block/media.scss
+++ b/src/app/components/Block/media.scss
@@ -32,6 +32,11 @@
     [data-provider="tiktok"] {
       top: calc(50% - 361px);
 
+      // Ensure no scroll bar on iframe
+      iframe {
+          max-height: unset !important;
+      }
+
       @media #{$mq-gt-md} {
         width: $unit * 33;
         max-width: 42.5%;
@@ -41,6 +46,37 @@
           left: unset;
         }
       }
+    }
+  }
+
+  .phone-frame {
+    height: 100%;
+    max-height: 85vh;
+
+    filter: drop-shadow(2px 4px 6px gold);
+
+    @media #{$mq-gt-md} {
+      width: $unit * 33;
+      max-width: 42.5%;
+      left: 75px;
+    }
+
+    & > * {
+      position: fixed;
+      max-width: 395px !important;
+      max-height: 85vh;
+      background-color: transparent;
+      border: 0;
+      padding: 0;
+      margin: auto;
+
+      top: calc(50% - 361px);
+      height: 100%;
+      width: 100%;
+
+      // Horizontally center unless on large screen
+      left: 50%;
+      transform: translateX(-50%);
     }
   }
 

--- a/src/app/components/Block/media.scss
+++ b/src/app/components/Block/media.scss
@@ -27,6 +27,21 @@
         -webkit-transform: translateZ(0);
       }
     }
+
+    // Position the TikTok frame so it's vertically centered, and floats left/right on larger screens
+    [data-provider="tiktok"] {
+      top: calc(50% - 361px);
+
+      @media #{$mq-gt-md} {
+        width: $unit * 33;
+        max-width: 42.5%;
+
+        &.u-pull-right {
+          right: 0;
+          left: unset;
+        }
+      }
+    }
   }
 
   .has-inset-media & > :not(.Block-mediaCaption) {

--- a/src/app/components/Block/media.scss
+++ b/src/app/components/Block/media.scss
@@ -63,17 +63,26 @@
 
     & > * {
       position: fixed;
-      max-width: 395px !important;
-      max-height: 85vh;
-      width: 100%;
+
+      height: 85vh;
+      top: 12%;
+
+      @media #{$mq-lt-md} {
+        height: 95vh;
+        top: 25px;
+      }
+
+      // max-width: 100% !important;
+      max-height: 700px !important;
+
       aspect-ratio: 9 / 16;
 
-      top: calc(50% - 361px);
       border: 0;
       padding: 0;
       margin: auto;
 
       background-color: transparent;
+      border-radius: 7px;
 
       // Horizontally center unless on large screen
       left: 50%;

--- a/src/app/components/InteractiveEmbed/index.js
+++ b/src/app/components/InteractiveEmbed/index.js
@@ -60,6 +60,33 @@ const InteractiveEmbed = ({ url, providerType, alignment, isFull }) => {
       const normalisedHTML = normaliseHTML(data.html, providerType);
       const documentFragment = document.createRange().createContextualFragment(normalisedHTML);
 
+      // For TikTok embeds inside a block, we want to show and hide the embed based on whether its inview or not.
+      //
+      // This will fix the autoplay behaviour (prevents it from finishing the video while off-screen)
+      if (providerType === 'tiktok' && embedContainerEl.parentNode.classList.contains('Block-media')) {
+        const blockContaining = embedContainerEl.parentNode;
+        let hasStarted = false;
+
+        const config = {
+          rootMargin: '0px -100px',
+          threshold: 0
+        }
+
+        const handler = (entries) => {
+          entries.forEach((entry) => {
+            if (!entry.isIntersecting) {
+              embedContainerEl.style = 'display: none';
+            } else {
+              embedContainerEl.style = 'display: block';
+            }
+          });
+        }
+
+        const observer = new IntersectionObserver(handler, config);
+        observer.observe(blockContaining);
+      }
+
+      // Insert the embed into the DOM
       embedContainerEl.innerHTML = '';
       embedContainerEl.appendChild(documentFragment);
 

--- a/src/app/components/InteractiveEmbed/index.js
+++ b/src/app/components/InteractiveEmbed/index.js
@@ -15,6 +15,7 @@ const SUPPORTED_PROVIDER_TYPES = [
   'soundcloud',
   'vimeo',
   'youtube',
+  'tiktok',
   'youtubeplaylist'
 ];
 const LOADERS_ENDPOINT = `https://${
@@ -26,7 +27,7 @@ const InteractiveEmbed = ({ url, providerType, alignment, isFull }) => {
   const isSupportedProviderType = SUPPORTED_PROVIDER_TYPES.indexOf(providerType) > -1;
 
   if (!isSupportedProviderType) {
-    return '<div></div>';
+    return document.createElement('div');
   }
 
   const hasAspectRatio = providerType === 'vimeo' || providerType.indexOf('youtube') === 0;
@@ -100,7 +101,7 @@ export const transformElement = el => {
   const url = el.getAttribute('itemid');
   const providerType = el.getAttribute('data-provider');
   const configString = grabPrecedingConfigString(el);
-  const descriptorAlignment = el._descriptor ? EMBED_ALIGNMENT_MAP[el._descriptor.props.align] : undefined;
+  const descriptorAlignment = el._descriptor ? EMBED_ALIGNMENT_MAP[el._descriptor.props.alignment] : undefined;
   const [, alignment] = configString.match(ALIGNMENT_PATTERN) || [, descriptorAlignment];
 
   substitute(

--- a/src/app/components/InteractiveEmbed/index.lazy.scss
+++ b/src/app/components/InteractiveEmbed/index.lazy.scss
@@ -38,6 +38,7 @@
     padding-top: 150%;
     padding-left: 10px;
     padding-right: 10px;
+    max-height: 800px;
 }
 
 .InteractiveEmbed iframe {

--- a/src/app/components/InteractiveEmbed/index.lazy.scss
+++ b/src/app/components/InteractiveEmbed/index.lazy.scss
@@ -31,6 +31,15 @@
   padding: 0;
 }
 
+/* If TikTok embed doesn't load, at least show a 16x9 black box that resembles a phone.
+   If it does load, this element is deleted by Presentation Layer. */
+.InteractiveEmbed[data-provider='tiktok'] blockquote.tiktok-embed section {
+    background: black;
+    padding-top: 150%;
+    padding-left: 10px;
+    padding-right: 10px;
+}
+
 .InteractiveEmbed iframe {
   width: 100% !important;
 }

--- a/src/app/components/InteractiveEmbed/index.lazy.scss
+++ b/src/app/components/InteractiveEmbed/index.lazy.scss
@@ -24,6 +24,13 @@
   width: 100% !important;
 }
 
+.InteractiveEmbed[data-provider='tiktok'] blockquote.tiktok-embed {
+  max-width: 325px !important;
+  background-color: transparent;
+  border: 0;
+  padding: 0;
+}
+
 .InteractiveEmbed iframe {
   width: 100% !important;
 }

--- a/src/app/constants.js
+++ b/src/app/constants.js
@@ -9,6 +9,7 @@ export const LG_RATIO_PATTERN = /lg(\d+x\d+)/;
 export const XL_RATIO_PATTERN = /xl(\d+x\d+)/;
 export const VIDEO_MARKER_PATTERN = /(?:video|youtube)(\w+)/;
 export const SCROLLPLAY_PCT_PATTERN = /scrollplay(\d+)/;
+export const BLOCK_BACKGROUND_COLOUR_PATTERN = /background([0-9a-fA-F]{6})/;
 
 export const SELECTORS = {
   MAIN: 'main#content',


### PR DESCRIPTION
A proof of concept to allow TikTok interactives to be used as block media.

Adds:
- `background` option to blocks (eg. `#blockpiecemealrightbackground00297e`, `#blockpiecemealrightbackground007bc7`)

Example usage:

![ezgif com-optimize](https://github.com/abcnews/odyssey/assets/6702746/7baf65aa-b6db-4857-a3ca-36b62a3c2ad0)




