### PR TITLE
Ignore missing media

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "odyssey",
-			"version": "7.2.13",
+			"version": "7.3.2",
 			"license": "MIT",
 			"dependencies": {
 				"@abcaustralia/analytics-datalayer": "^23.0.0",
@@ -151,12 +151,12 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.22.13",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-			"integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+			"integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/highlight": "^7.22.13",
+				"@babel/highlight": "^7.23.4",
 				"chalk": "^2.4.2"
 			},
 			"engines": {
@@ -283,12 +283,12 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
-			"integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.5.tgz",
+			"integrity": "sha512-BPssCHrBD+0YrxviOa3QzpqwhNIXKEtOa2jQrm4FlmkC2apYgRnQcmPWiGZDlGxiNtltnUFolMe8497Esry+jA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.23.0",
+				"@babel/types": "^7.23.5",
 				"@jridgewell/gen-mapping": "^0.3.2",
 				"@jridgewell/trace-mapping": "^0.3.17",
 				"jsesc": "^2.5.1"
@@ -589,9 +589,9 @@
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-			"integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+			"version": "7.23.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
+			"integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
@@ -644,9 +644,9 @@
 			}
 		},
 		"node_modules/@babel/highlight": {
-			"version": "7.22.20",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
-			"integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
+			"version": "7.23.4",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
+			"integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-validator-identifier": "^7.22.20",
@@ -729,9 +729,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-			"integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.5.tgz",
+			"integrity": "sha512-hOOqoiNXrmGdFbhgCzu6GiURxUgM27Xwd/aPuu8RfHEZPBzL1Z54okAHAQjXfcQNwvrlkAmAp4SlRTZ45vlthQ==",
 			"dev": true,
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -2105,19 +2105,19 @@
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.0.tgz",
-			"integrity": "sha512-t/QaEvyIoIkwzpiZ7aoSKK8kObQYeF7T2v+dazAYCb8SXtp58zEVkWW7zAnju8FNKNdr4ScAOEDmMItbyOmEYw==",
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.5.tgz",
+			"integrity": "sha512-czx7Xy5a6sapWWRx61m1Ke1Ra4vczu1mCTtJam5zRTBOonfdJ+S/B6HYmGYu3fJtr8GGET3si6IhgWVBhJ/m8w==",
 			"dev": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.22.13",
-				"@babel/generator": "^7.23.0",
+				"@babel/code-frame": "^7.23.5",
+				"@babel/generator": "^7.23.5",
 				"@babel/helper-environment-visitor": "^7.22.20",
 				"@babel/helper-function-name": "^7.23.0",
 				"@babel/helper-hoist-variables": "^7.22.5",
 				"@babel/helper-split-export-declaration": "^7.22.6",
-				"@babel/parser": "^7.23.0",
-				"@babel/types": "^7.23.0",
+				"@babel/parser": "^7.23.5",
+				"@babel/types": "^7.23.5",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
 			},
@@ -2126,12 +2126,12 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
-			"integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.5.tgz",
+			"integrity": "sha512-ON5kSOJwVO6xXVRTvOI0eOnWe7VdUcIpsovGo9U/Br4Ie4UVFQTboO2cYnDhAGU6Fp+UxSiT+pMft0SMHfuq6w==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-string-parser": "^7.22.5",
+				"@babel/helper-string-parser": "^7.23.4",
 				"@babel/helper-validator-identifier": "^7.22.20",
 				"to-fast-properties": "^2.0.0"
 			},

--- a/src/app/meta/index.js
+++ b/src/app/meta/index.js
@@ -178,7 +178,10 @@ export const initMeta = terminusDocument => {
                 break;
               case 'Image':
               case 'ImageProxy':
-                if (!memo.imagesById[id]) {
+                // It's possible for the `media` key to be undefined if it's an ImageProxy
+                // pointing at a deleted image. The `!!media` condition will stop Odyssey
+                // falling over in that case.
+                if (!memo.imagesById[id] && !!media) {
                   memo.images.push(doc);
                   memo.imagesById[id] = doc;
                   memo.imagesByBinaryKey[media.image.primary.binaryKey] = doc;


### PR DESCRIPTION
Although it shouldn't be possible in live, it's possible that linked media assets are missing in preview. This prevents Odyssey from crashing on initaialisation when that's the case.