### PR TITLE
feature: allow interactives to dictate whether Odyssey loads

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ import './unveil';
 window.__IS_ODYSSEY_FORMAT__ = true;
 window.__ODYSSEY_EXEC__ = null;
 
-const go = async () => {
+const go = () => {
   // Don't run on IE or old-Edge, which we no longer support
   if (/* IE <= 9 */ (document.all && !window.atob) || /* IE >= 10 */ window.navigator.msPointerEnabled) {
     return debug('Trident-based browsers are not supported');
@@ -55,7 +55,8 @@ proxy('odyssey').then(() => {
    * In order to fall back when an interactive isn't supported, we need to
    * intercept Odysesy loading.
    *
-   * Do this by adding `?defer` to the script src (or for local dev use `/index.js?a=/res/sites/news-projects/odyssey/?defer`)
+   * Do this by adding `?defer` to the Odyssey script src (or for local dev
+   * use `/index.js?a=/res/sites/news-projects/odyssey/?defer`)
    *
    * Inside your interactive, run your own compatibility checks then initialise
    * Odyssey with:

--- a/src/index.js
+++ b/src/index.js
@@ -66,7 +66,7 @@ proxy('odyssey').then(() => {
    * go();
    * ```
    */
-  const shouldDeferUntilInteractiveReady = document.querySelector('script[src*="/res/sites/news-projects/odyssey/"]')?.src?.includes('?defer');
+  const shouldDeferUntilInteractiveReady = document.querySelector('script[src*="/res/sites/news-projects/odyssey/"][src*="index.js"]')?.src?.includes('?defer');
 
   if (shouldDeferUntilInteractiveReady) {
     window.__ODYSSEY_EXEC__ = go;


### PR DESCRIPTION
In the Globey interactive we have a few extra checks (don't run in iPhone <= 7, don't run if the browser can't run Web GL).

But while we can bail out of our interactive, none of the fallback images are show because Odyssey has already removed them.

This PR allows the interactive itself to determine whether to load the Odyssey experience, or leave the fallback intact.

Edit: this was included in the recent WebGL article. You can see the [article](https://www.abc.net.au/news/2024-03-06/the-cloud-under-the-sea/103137378) and [fallback](https://www.abc.net.au/news/2024-03-06/the-cloud-under-the-sea/103137378#fallback) versions.