### PR TITLE
Add OAVP playable range threshold & absolute toggling

### DIFF
--- a/src/app/components/VideoPlayer/index.js
+++ b/src/app/components/VideoPlayer/index.js
@@ -223,7 +223,7 @@ const VideoPlayer = ({
 
       videoEl.pause();
     },
-    togglePlayback: (_event, wasScrollBased, newStatus) => {
+    togglePlayback: (_event, wasScrollBased) => {
       if (!wasScrollBased && !player.isAmbient) {
         player.isUserInControl = true;
       }

--- a/src/app/components/VideoPlayer/index.js
+++ b/src/app/components/VideoPlayer/index.js
@@ -168,6 +168,11 @@ const VideoPlayer = ({
     isAmbient,
     isScrollplay,
     scrollplayPct,
+    /**
+     * Set to `true` by the audio visual plugin to tighten the playback
+     * threshold so videos with audio are less likely to overlap
+     */
+    willPlayAudio: false,
     getTitle: () => title,
     getRect: () => {
       // Fixed players should use their parent's rect, as they're always in the viewport
@@ -218,7 +223,7 @@ const VideoPlayer = ({
 
       videoEl.pause();
     },
-    togglePlayback: (_event, wasScrollBased) => {
+    togglePlayback: (_event, wasScrollBased, newStatus) => {
       if (!wasScrollBased && !player.isAmbient) {
         player.isUserInControl = true;
       }
@@ -262,8 +267,8 @@ const VideoPlayer = ({
       isInitiallyPreferredPortraitContainer && portraitSources.length
         ? portraitSources
         : landscapeSources.length
-        ? landscapeSources
-        : sources;
+          ? landscapeSources
+          : sources;
     const source = candidateSources[isInitiallySmallViewport ? 0 : candidateSources.length - 1];
 
     if (source) {

--- a/src/app/components/VideoPlayer/players.js
+++ b/src/app/components/VideoPlayer/players.js
@@ -28,7 +28,7 @@ function _checkIfPlayersNeedToBeToggled(client) {
     const rect = player.getRect();
     const isInPlayableRange =
       player.isAmbient && typeof player.scrollplayPct !== 'number'
-        ? proximityCheck(rect, client, AMBIENT_PLAYABLE_RANGE)
+        ? proximityCheck(rect, client, player.willPlayAudio ? 0 : AMBIENT_PLAYABLE_RANGE)
         : proximityCheck(rect, client, (player.scrollplayPct || 0) / -100);
 
     if (
@@ -36,7 +36,11 @@ function _checkIfPlayersNeedToBeToggled(client) {
       (typeof player.isInPlayableRange !== 'undefined' && isInPlayableRange !== player.isInPlayableRange)
     ) {
       enqueue(function _toggleVideoPlay() {
-        player.togglePlayback(null, true);
+        if (isInPlayableRange) {
+          player.play();
+        } else {
+          player.pause();
+        }
       });
     }
 


### PR DESCRIPTION
1. OAVP playable range needs to be shorter when playing audio, otherwise videos will play audio when they're not even on the screen. This is super bad when there's dialog because you can end up with multiple videos playing at the same time, talking over each other.
2. Toggling was causing videos to get out of sync (playing when offscreen/pausing when on). Instead of toggling the video play status, perform the actual action.