### PR TITLE
feature: FormatCredit

### DIFF
--- a/src/app/components/FormatCredit/index.js
+++ b/src/app/components/FormatCredit/index.js
@@ -9,12 +9,10 @@ const FormatCredit = () => {
   styles.use();
 
   return html`
-    <div class="FormatCredit">
-      <p>
-        <span>Odyssey format by </span>
-        <a href=${LINK_URL} onclick=${LINK_TRACKER}>ABC News Story Lab</a>
-      </p>
-    </div>
+    <p class="FormatCredit">
+      <span>Odyssey format</span>
+      <a class="FormatCredit__tag" href=${LINK_URL} onclick=${LINK_TRACKER}><span>ABC News Story Lab</span></a>
+    </p>
   `;
 };
 

--- a/src/app/components/FormatCredit/index.lazy.scss
+++ b/src/app/components/FormatCredit/index.lazy.scss
@@ -41,6 +41,7 @@
     &:focus span {
       color: var(--od-colour-text-inverse);
       background-color: var(--od-button-secondary-hover);
+      text-decoration: underline;
     }
 
     &:active span {

--- a/src/app/components/FormatCredit/index.lazy.scss
+++ b/src/app/components/FormatCredit/index.lazy.scss
@@ -12,8 +12,8 @@
     color: inherit;
   }
 
-  // pill/tag
-  &__tag {
+  // pill/tag w specificity to fight Odyssey richtext links
+  [class*=u-richtext] &__tag {
 
     // Style inner span to avoid leaky styles from Odyssey/story customisations
     span {

--- a/src/app/components/FormatCredit/index.lazy.scss
+++ b/src/app/components/FormatCredit/index.lazy.scss
@@ -1,16 +1,12 @@
 @import '../../constants';
 
 .FormatCredit {
-  color: $color-black;
+  color: var(--od-colour-text-primary);
   font-family: var(--od-font-stack-serif);
   font-size: 1rem;
   font-style: normal;
   font-weight: 600;
   line-height: 125%;
-
-  .u-richtext-invert & {
-    color: $color-white;
-  }
 
   .FormatCredit>* {
     color: inherit;

--- a/src/app/components/FormatCredit/index.lazy.scss
+++ b/src/app/components/FormatCredit/index.lazy.scss
@@ -1,23 +1,51 @@
 @import '../../constants';
 
 .FormatCredit {
-  color: $color-black-transparent-75;
-  font-family: var(--od-font-stack-sans);
+  color: $color-black;
+  font-family: var(--od-font-stack-serif);
   font-size: 1rem;
-  font-weight: bold;
-  line-height: 1.555555556;
-  text-transform: uppercase;
-  letter-spacing: 0.0625em;
+  font-style: normal;
+  font-weight: 600;
+  line-height: 125%;
 
   .u-richtext-invert & {
-    color: $color-white-transparent-75;
+    color: $color-white;
   }
 
-  .FormatCredit > * {
+  .FormatCredit>* {
     color: inherit;
   }
 
-  & a {
-    white-space: nowrap;
+  // pill/tag
+  &__tag {
+
+    // Style inner span to avoid leaky styles from Odyssey/story customisations
+    span {
+      margin-left: .75rem;
+      border-radius: 6.25rem;
+      // These are important because some stories override link colours.
+      // If this is important to override, please change the var instead.
+      color: var(--od-colour-theme-text-accent);
+      background-color: var(--od-colour-theme-tag);
+      padding: 0.75rem;
+      font-family: var(--od-font-stack-sans);
+      font-size: 0.875rem;
+      font-style: normal;
+      font-weight: 700;
+      line-height: normal;
+      white-space: nowrap;
+      transition: var(--dls-link-transition);
+    }
+
+    &:hover span,
+    &:focus span {
+      color: var(--od-colour-text-inverse);
+      background-color: var(--od-button-secondary-hover);
+    }
+
+    &:active span {
+      color: var(--od-colour-text-inverse);
+      background-color: var(--od-button-secondary-active);
+    }
   }
 }

--- a/src/app/components/legacy/FormatCredit/index.js
+++ b/src/app/components/legacy/FormatCredit/index.js
@@ -1,0 +1,23 @@
+import html from 'nanohtml';
+import { track } from '../../../utils/behaviour';
+import styles from './index.lazy.scss';
+
+const LINK_URL = '/news/interactives/';
+const LINK_TRACKER = () => track('format-credit-link', '*');
+
+const FormatCredit = () => {
+  styles.use();
+
+  return html`
+    <div class="FormatCredit--legacy">
+      <p>
+        <span class="FormatCredit__wrapper">
+        <span>Odyssey format by </span>
+        <a href=${LINK_URL} onclick=${LINK_TRACKER}>ABC News Story Lab</a>
+        </span>
+      </p>
+    </div>
+  `;
+};
+
+export default FormatCredit;

--- a/src/app/components/legacy/FormatCredit/index.lazy.scss
+++ b/src/app/components/legacy/FormatCredit/index.lazy.scss
@@ -1,0 +1,27 @@
+@import '../../../constants';
+
+.FormatCredit--legacy {
+  color: $color-black-transparent-75;
+
+  // Avoid inherited paragraph styles
+  .FormatCredit__wrapper {
+    font-family: var(--od-font-stack-sans);
+    font-size: 1rem;
+    font-weight: bold;
+    line-height: 1.555555556;
+    text-transform: uppercase;
+    letter-spacing: 0.0625em;
+  }
+
+  .u-richtext-invert & {
+    color: $color-white-transparent-75;
+  }
+
+  .FormatCredit>* {
+    color: inherit;
+  }
+
+  & a {
+    white-space: nowrap;
+  }
+}

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -2,6 +2,7 @@ import api from './api';
 import { transformSection as transformSectionIntoBackdrop } from './components/Backdrop';
 import { transformSection as transformSectionIntoBlock } from './components/Block';
 import FormatCredit from './components/FormatCredit';
+import FormatCreditLegacy from './components/legacy/FormatCredit';
 import { transformSection as transformSectionIntoGallery } from './components/Gallery';
 import { Lite as LiteHeader, transformSection as transformSectionIntoHeader } from './components/Header';
 import { transformMarker as transformMarkerIntoHR } from './components/HR';
@@ -311,7 +312,7 @@ export default terminusDocument => {
 
   // Append format credit for non-DSI stories
   if (meta.productionUnit !== 'EDL team' && (meta.infoSource || {}).name !== 'Digital Story Innovation Team') {
-    append(mainEl, FormatCredit());
+    append(mainEl, meta.isFuture ? FormatCredit() : FormatCreditLegacy());
     debug('Appended Odyssey format credit');
   }
 


### PR DESCRIPTION
Light:

<img width="426" alt="image" src="https://github.com/abcnews/odyssey/assets/49600/2e499307-0ba3-4397-bf1a-bf774593d8ec">
<img width="368" alt="image" src="https://github.com/abcnews/odyssey/assets/49600/6923d30c-6f2e-4022-b5d0-9b67bc4f8b1d">

---
Night:

<img width="356" alt="image" src="https://github.com/abcnews/odyssey/assets/49600/7c286798-c946-4fb8-9391-8157a54024ec">
<img width="354" alt="image" src="https://github.com/abcnews/odyssey/assets/49600/bd4218d9-11d9-44e6-9f36-aacbfba0c7c7">

---
Custom:

<img width="419" alt="image" src="https://github.com/abcnews/odyssey/assets/49600/8e421428-da51-4aa5-ba2f-caaae0953b8c">
<img width="384" alt="image" src="https://github.com/abcnews/odyssey/assets/49600/dd87db0e-576d-4565-9a11-8a6c6be20bfc">

---
Legacy format still intact:

<img width="585" alt="image" src="https://github.com/abcnews/odyssey/assets/49600/167cbbd0-59d8-40ac-85e5-28b798193778">
