### PR TITLE
Extract the caption from embedded videos correctly in future news

### DIFF
--- a/src/app/components/Caption/index.js
+++ b/src/app/components/Caption/index.js
@@ -58,6 +58,7 @@ export const createFromElement = (el, unlink) => {
   const clone = el.cloneNode(true);
   const config = {
     url: `/news/${clone.getAttribute('id')}`,
+    // Future news has the caption text inside the 'p' el, while legacy does not
     text: [MOCK_TEXT]
       .concat(Array.from(($('figcaption p', clone) || $('figcaption', clone) || MOCK_ELEMENT).childNodes))
       .filter(isText)

--- a/src/app/components/Caption/index.js
+++ b/src/app/components/Caption/index.js
@@ -59,7 +59,7 @@ export const createFromElement = (el, unlink) => {
   const config = {
     url: `/news/${clone.getAttribute('id')}`,
     text: [MOCK_TEXT]
-      .concat(Array.from(($('figcaption', clone) || MOCK_ELEMENT).childNodes))
+      .concat(Array.from(($('figcaption p', clone) || $('figcaption', clone) || MOCK_ELEMENT).childNodes))
       .filter(isText)
       .sort((a, b) => b.nodeValue.length - a.nodeValue.length)[0].nodeValue,
     attribution: (($('cite', clone) || MOCK_ELEMENT).textContent || '').slice(1, -1).trim(),


### PR DESCRIPTION
Spotted this issue:

![image](https://github.com/user-attachments/assets/8f72904c-c447-4128-92ec-9e942fa84bad)

It still works on the legacy design.

![image](https://github.com/user-attachments/assets/8f1834ee-7d02-43fb-bc28-a4780af52a6a)
