### PR TITLE
Make #image<id> embeds possible

### DIFF
--- a/src/app/components/Picture/index.js
+++ b/src/app/components/Picture/index.js
@@ -26,6 +26,7 @@ const RATIO_SIZE_WIDTH_INDICES = {
 /**
  *
  * @param {object} obj
+ * @param {any} [obj.imageDoc]
  * @param {string} [obj.src]
  * @param {string|null} [obj.alt]
  * @param {object} [obj.ratios]
@@ -35,6 +36,7 @@ const RATIO_SIZE_WIDTH_INDICES = {
  * @returns {HTMLElement}
  */
 const Picture = ({
+  imageDoc,
   src = SMALLEST_IMAGE,
   alt = '',
   ratios = {},
@@ -57,7 +59,7 @@ const Picture = ({
     [MQ.XL]: src
   };
 
-  const imageDoc = lookupImageByAssetURL(src); // Will only work if image's document was catalogued during initMeta
+  imageDoc = imageDoc || lookupImageByAssetURL(src); // Will only work if image's document was catalogued during initMeta
 
   if (imageDoc) {
     const { renditions } = getImages(imageDoc, WIDTHS);

--- a/src/app/constants.js
+++ b/src/app/constants.js
@@ -8,6 +8,7 @@ export const MD_RATIO_PATTERN = /md(\d+x\d+)/;
 export const LG_RATIO_PATTERN = /lg(\d+x\d+)/;
 export const XL_RATIO_PATTERN = /xl(\d+x\d+)/;
 export const VIDEO_MARKER_PATTERN = /(?:video|youtube)(\w+)/;
+export const IMAGE_MARKER_PATTERN = /(?:image)(\d+)/;
 export const SCROLLPLAY_PCT_PATTERN = /scrollplay(\d+)/;
 
 export const SELECTORS = {

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -6,7 +6,10 @@ import FormatCreditLegacy from './components/legacy/FormatCredit';
 import { transformSection as transformSectionIntoGallery } from './components/Gallery';
 import { Lite as LiteHeader, transformSection as transformSectionIntoHeader } from './components/Header';
 import { transformMarker as transformMarkerIntoHR } from './components/HR';
-import { transformElement as transformElementIntoImageEmbed } from './components/ImageEmbed';
+import {
+  transformElement as transformElementIntoImageEmbed,
+  transformMarker as transformMarkerIntoImageEmbed
+} from './components/ImageEmbed';
 import { transformElement as transformElementIntoInteractiveEmbed } from './components/InteractiveEmbed';
 import MasterGallery, { register as registerWithMasterGallery } from './components/MasterGallery';
 import {
@@ -155,6 +158,7 @@ export default terminusDocument => {
     'series',
     'share',
     'video',
+    'image',
     'youtube',
     'related',
     'tease',
@@ -186,6 +190,9 @@ export default terminusDocument => {
       case 'video':
       case 'youtube':
         transformMarkerIntoVideoEmbed(marker);
+        break;
+      case 'image':
+        transformMarkerIntoImageEmbed(marker);
         break;
       case 'related':
       case 'tease':


### PR DESCRIPTION
This is a little messy, but gets the job done. The main reason it's messy is because of poor typing and handing of
responses from Terminus. We should address this by moving to the GraphQL endpoint.