### PR TITLE
Enable #image<id> embeds

### DIFF
--- a/src/app/components/VideoControls/index.js
+++ b/src/app/components/VideoControls/index.js
@@ -23,7 +23,7 @@ const STEP_SECONDS = 5;
 /**
  * Initialise a video player controls element
  * @param {import('../VideoPlayer').VideoPlayerAPI} player
- * @param {boolean} hasAmbientParent
+ * @param {boolean} [hasAmbientParent]
  * @param {HTMLElement} [videoDuration]
  * @returns {VideoControlsEl}
  */

--- a/src/app/components/VideoEmbed/index.js
+++ b/src/app/components/VideoEmbed/index.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { getMountValue, isMount } from '@abcnews/mount-utils';
 import { url2cmid } from '@abcnews/url2cmid';
 import cn from 'classnames';
@@ -38,7 +39,7 @@ export const transformElement = el => {
   const playerIdEl = $('[data-component="VideoPlayer"]', el);
   const expiredMediaWarningEl = $('[data-component="ExpiredMediaWarning"]', el);
   const videoId = isVideoMarker
-    ? mountValue.match(VIDEO_MARKER_PATTERN)[1]
+    ? mountValue.match(VIDEO_MARKER_PATTERN)?.[1]
     : playerIdEl
     ? detectVideoId(el)
     : expiredMediaWarningEl
@@ -57,8 +58,8 @@ export const transformElement = el => {
   const unlink = configString.indexOf('unlink') > -1;
 
   const isYouTube = isVideoMarker && mountValue.indexOf('youtube') === 0;
-  const captionEl = !isVideoMarker ? createCaptionFromElement(el, unlink) : null;
-  const title = captionEl ? captionEl.children[0].textContent : null;
+  const captionEl = !isVideoMarker ? createCaptionFromElement(el, unlink) : undefined;
+  const title = captionEl ? captionEl.children[0].textContent : undefined;
 
   const options = {
     alignment,
@@ -72,17 +73,18 @@ export const transformElement = el => {
     ,
     configString.indexOf('autoplay') > -1 ? '0' : ''
   ];
-  const scrollplayPct = scrollplayPctString.length > 0 && Math.max(0, Math.min(100, +scrollplayPctString));
+  const scrollplayPct =
+    (scrollplayPctString.length > 0 && Math.max(0, Math.min(100, +scrollplayPctString))) || undefined;
 
   const playerOptions = {
     videoId,
     ratios: getRatios(configString),
-    title,
+    title: title || undefined,
     isAmbient: configString.indexOf('ambient') > -1 ? true : undefined,
     isLoop: configString.indexOf('loop') > -1 ? true : configString.indexOf('once') > -1 ? false : undefined,
     isMuted: configString.indexOf('muted') > -1 ? true : undefined,
     scrollplayPct,
-    videoDuration: $('time', el),
+    videoDuration: $('time', el) || undefined
   };
 
   substitute(

--- a/src/app/components/VideoPlayer/index.js
+++ b/src/app/components/VideoPlayer/index.js
@@ -13,22 +13,23 @@ import styles from './index.lazy.scss';
 
 /**
  * @typedef {object} VideoPlayerAPI
- * @prop {boolean} hasNativeUI
- * @prop {boolean} isAmbient
+ * @prop {boolean} [hasNativeUI]
+ * @prop {boolean} [isAmbient]
  * @prop {boolean} isScrollplay
  * @prop {number | undefined} scrollplayPct
- * @prop {boolean} willPlayAudio
+ * @prop {boolean} [willPlayAudio]
  * @prop {boolean} [isInPlayableRange]
  * @prop {string} [alternativeText]
  * @prop {() => string} getTitle
  * @prop {() => DOMRect} getRect
- * @prop {() => HTMLVideoElement} getVideoEl
+ * @prop {() => HTMLVideoElement} [getVideoEl]
  * @prop {() => boolean} isMuted
  * @prop {(shouldBeMuted: boolean) => void} setMuted
  * @prop {(this: HTMLElement, event: PointerEvent) => void} toggleMutePreference
  * @prop {() => boolean} isPaused
  * @prop {() => void} play
  * @prop {() => void} pause
+ * @prop {() => void} [resize]
  * @prop {(_event: Event, wasScrollBased: boolean) => void} togglePlayback
  * @prop {boolean} [isUserInControl]
  * @prop {(pct: number) => void} jumpToPct
@@ -58,7 +59,7 @@ let hasSubscribed = false;
  * @param {boolean} [config.isLoop] Should the video loop?
  * @param {boolean} [config.isMuted] Should the video be muted?
  * @param {number} [config.scrollplayPct] What protion of the video should be visible for play on scroll
- * @param {HTMLElement} [config.videoDuration] A <time> element to display the video duration.
+ * @param {Element} [config.videoDuration] A <time> element to display the video duration.
  * @returns
  */
 const VideoPlayer = ({
@@ -347,7 +348,7 @@ const VideoPlayer = ({
     }
   });
 
-  videoControlsEl = VideoControls(player, isAmbient, videoDuration);
+  videoControlsEl = VideoControls(player, isAmbient, videoDuration instanceof HTMLElement ? videoDuration : undefined);
 
   /**
    * Jump to a time on the video
@@ -439,11 +440,13 @@ function updateUI(player) {
 
   player.hasNativeUI = shouldBeNative;
 
-  toggleBooleanAttributes(player.getVideoEl(), {
-    controls: shouldBeNative,
-    playsinline: !shouldBeNative,
-    'webkit-playsinline': !shouldBeNative
-  });
+  if (player.getVideoEl) {
+    toggleBooleanAttributes(player.getVideoEl(), {
+      controls: shouldBeNative,
+      playsinline: !shouldBeNative,
+      'webkit-playsinline': !shouldBeNative
+    });
+  }
 }
 
 function _checkIfVideoPlayersNeedToUpdateUIBasedOnMedia() {
@@ -463,9 +466,11 @@ function _checkIfVideoPlayersNeedToUpdateUIBasedOnMedia() {
     enqueue(function _updateVideoPlayerUI() {
       updateUI(player);
 
-      if (wasPlaying && player.getVideoEl().scrollIntoView) {
+      if (wasPlaying && player.getVideoEl && player.getVideoEl().scrollIntoView) {
         enqueue(function _scrollVideoPlayerIntoView() {
-          player.getVideoEl().scrollIntoView(true);
+          if (player.getVideoEl) {
+            player.getVideoEl().scrollIntoView(true);
+          }
         });
       }
     });

--- a/src/app/components/YouTubePlayer/index.js
+++ b/src/app/components/YouTubePlayer/index.js
@@ -41,7 +41,7 @@ let nextId = 0;
 
 /**
  * Create a YouTubePlayer component
- * @param {Partial<YouTubePlayerConfig} config
+ * @param {Partial<YouTubePlayerConfig>} config
  * @returns {HTMLElement}
  */
 const YouTubePlayer = ({
@@ -89,6 +89,7 @@ const YouTubePlayer = ({
   let youtube;
   let youTubePlayerEl;
   let videoControlsEl;
+  /** @type {import('../VideoPlayer').VideoPlayerAPI} */
   let player;
   let fuzzyCurrentTime = 0;
   let fuzzyTimeout;
@@ -159,7 +160,7 @@ const YouTubePlayer = ({
 
           registerPlayer(player);
           players.push(player);
-          player.resize();
+          player.resize && player.resize();
 
           if (players.length === 1) {
             subscribe(_resizePlayers, true);

--- a/src/app/constants.js
+++ b/src/app/constants.js
@@ -8,6 +8,7 @@ export const MD_RATIO_PATTERN = /md(\d+x\d+)/;
 export const LG_RATIO_PATTERN = /lg(\d+x\d+)/;
 export const XL_RATIO_PATTERN = /xl(\d+x\d+)/;
 export const VIDEO_MARKER_PATTERN = /(?:video|youtube)(\w+)/;
+export const IMAGE_MARKER_PATTERN = /(?:image)(\d+)/;
 export const SCROLLPLAY_PCT_PATTERN = /scrollplay(\d+)/;
 
 export const SELECTORS = {

--- a/src/app/reset/index.js
+++ b/src/app/reset/index.js
@@ -26,7 +26,7 @@ const WHITESPACE_REMOVABLES = 'p';
 /**
  *
  * @param {Element} storyEl
- * @param {import('../meta').MetaData} meta
+ * @param {Partial<import('../meta').MetaData>} meta
  */
 function addDescriptorHints(storyEl, meta) {
   const storyElChildElements = Array.from(storyEl.children);
@@ -41,7 +41,7 @@ function addDescriptorHints(storyEl, meta) {
 /**
  * Pull the story element up one level in the DOM
  * @param {Element} storyEl
- * @param {import('../meta').MetaData} meta
+ * @param {Partial<import('../meta').MetaData>} meta
  * @returns {Element}
  */
 function promoteToMain(storyEl, meta) {
@@ -62,7 +62,7 @@ function promoteToMain(storyEl, meta) {
 /**
  * Perform a bunch of resets to start with a clean slate.
  * @param {Element} storyEl
- * @param {import('../meta').MetaData} meta
+ * @param {Partial<import('../meta').MetaData>} meta
  * @returns {Element}
  */
 export const reset = (storyEl, meta) => {

--- a/types.d.ts
+++ b/types.d.ts
@@ -39,15 +39,15 @@ interface TerminusArticle {
 }
 
 interface TerminusArticleEmbedded {
-  contributors: Contributor[];
-  javascript: Javascript[];
+  contributors?: Contributor[];
+  javascript?: Javascript[];
   locations: Location[];
-  mediaEmbedded: MediaEmbedded[];
-  mediaFeatured: MediaEmbedded[];
-  mediaRelated: MediaEmbedded[];
-  mediaThumbnail: MediaThumbnail;
+  mediaEmbedded?: MediaEmbedded[];
+  mediaFeatured?: MediaEmbedded[];
+  mediaRelated?: MediaEmbedded[];
+  mediaThumbnail?: MediaThumbnail;
   primaryContext: PrimaryContext;
-  subjects: Subject[];
+  subjects?: Subject[];
 }
 
 interface Contributor {


### PR DESCRIPTION
Take two. This is much simpler and cleaner. Using the `#image<id>` embed syntax now requires that the image document is
attached to the article via featured media.

There are some type improvements in here too.