### PR TITLE
Crop to centre on header media

### DIFF
--- a/src/app/components/Header/index.lazy.scss
+++ b/src/app/components/Header/index.lazy.scss
@@ -60,6 +60,9 @@ $abreastChildSpacing: $unit * 2.5;
 
   :not(.is-layered) > & {
     max-height: calc(100vh - var(--Main-offsetTop) - var(--Header-contentPeek));
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
   }
 
   .is-layered > & {


### PR DESCRIPTION
Header media is currently cropping to the top for windows with wide aspect ratio. This means the bottom of the image is
cut off, but the top isn't. It should be cropping to center so top and bottom are cropped out evenly. This fixes that.