### PR TITLE
bug: alt text appearing in StoryTeaserEmbed on the app

### DIFF
--- a/src/app/components/StoryTeaserEmbed/index.js
+++ b/src/app/components/StoryTeaserEmbed/index.js
@@ -39,7 +39,11 @@ export const transformElement = el => {
   substitute(el, pullRightWrapperEl);
   pullRightWrapperEl.appendChild(el);
   imageURL = imageURL.replace(/[“”]/g, '');
-  $$('noscript', el).forEach(noscriptEl => noscriptEl.parentElement.removeChild(noscriptEl));
+
+  // remove noscript and screen reader elements before getting the text content
+  $$('noscript,[data-component="ScreenReaderOnly"]', el).forEach(noscriptEl =>
+    noscriptEl.parentElement.removeChild(noscriptEl)
+  );
 
   const description = (el.textContent || '')
     .replace(title, '')


### PR DESCRIPTION
The app has extra text marked up with `[data-component="ScreenReaderOnly"]` that we must remove.

![image](https://github.com/user-attachments/assets/6f498b70-6532-404a-92ab-3234e9832b29)
