### PR TITLE
Support 'use original image' for header images

### DIFF
--- a/e2e/visual.spec.js
+++ b/e2e/visual.spec.js
@@ -86,6 +86,7 @@ ARTICLES.forEach(([article, { targets }]) => {
                 const locator = page.locator(target).first();
                 await expect(locator).toHaveCount(1);
                 await locator.scrollIntoViewIfNeeded();
+                await page.waitForTimeout(100);
                 await expect(locator).toHaveScreenshot({
                   timeout: 30000,
                   stylePath: join(__dirname, 'screenshots.css')

--- a/e2e/visual.spec.js
+++ b/e2e/visual.spec.js
@@ -74,6 +74,10 @@ ARTICLES.forEach(([article, { targets }]) => {
           test.describe(`${resolution.join(',')}`, () => {
             test.beforeEach(async ({ page }) => {
               await page.setViewportSize({ width: resolution[0], height: resolution[1] });
+              // Make sure all images are loaded before taking screenshots
+              for (const img of await page.locator('#content > :has(.Picture):not(.MasterGallery)').all()) {
+                await img.scrollIntoViewIfNeeded();
+              }
             });
 
             // Above the fold is being troublesome and doesn't add much

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -15,6 +15,7 @@ export default defineConfig({
   // workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
+  timeout: 60000,
   expect: {
     toHaveScreenshot: { maxDiffPixels: 500, maxDiffPixelRatio: 0.02 }
   },

--- a/src/app/components/Header/index.js
+++ b/src/app/components/Header/index.js
@@ -9,7 +9,6 @@ import { $, detach, detectVideoId, getChildImage, isElement } from '../../utils/
 import { clampNumber, formattedDate, getRatios, isDefined } from '../../utils/misc';
 import Picture from '../Picture';
 import ScrollHint from '../ScrollHint';
-import { activate as activateUParallax } from '../UParallax';
 import VideoPlayer from '../VideoPlayer';
 import YouTubePlayer from '../YouTubePlayer';
 import styles from './index.lazy.scss';
@@ -77,6 +76,9 @@ const Header = ({
     xl: isAbreast ? '1x1' : ratios.xl
   };
 
+  /**
+   * @type {HTMLElement | undefined}
+   */
   let mediaEl;
 
   if (imgEl) {
@@ -100,11 +102,6 @@ const Header = ({
           isLoop: shouldVideoPlayOnce ? false : undefined,
           isInvariablyAmbient: true
         });
-  }
-
-  if (mediaEl && !isLayered && !isAbreast) {
-    // mediaEl.classList.add('u-parallax');
-    // activateUParallax(mediaEl);
   }
 
   const titleEl = html`

--- a/src/app/components/Header/index.js
+++ b/src/app/components/Header/index.js
@@ -24,6 +24,7 @@ import styles from './index.lazy.scss';
  * @prop {boolean} isPale
  * @prop {boolean} isVideoYouTube
  * @prop {Partial<import('src/app/meta').MetaData>} meta
+ * @prop {{value: number; units: string}} [mediaWidth]
  * @prop {Element[]} miscContentEls
  * @prop {import('../../utils/misc').Ratios} ratios
  * @prop {boolean} shouldVideoPlayOnce
@@ -45,6 +46,7 @@ const Header = ({
   isPale,
   isVideoYouTube,
   meta = {},
+  mediaWidth,
   miscContentEls = [],
   ratios = {},
   shouldVideoPlayOnce,
@@ -165,7 +167,10 @@ const Header = ({
     <div class="${className}" data-scheme="${scheme}" data-theme="${THEME}">
       ${mediaEl
         ? html`
-            <div class="Header-media${isLayered && !isAbreast && mediaEl.tagName !== 'DIV' ? ' u-parallax' : ''}">
+            <div
+              class="Header-media${isLayered && !isAbreast && mediaEl.tagName !== 'DIV' ? ' u-parallax' : ''}"
+              style="${mediaWidth ? '--od-header-media-width: ' + mediaWidth.value + mediaWidth.units : ''}"
+            >
               ${!isLayered && !isAbreast && !meta.isFuture ? ScrollHint() : null} ${mediaEl}
             </div>
           `
@@ -256,7 +261,8 @@ export const transformSection = (section, meta) => {
   const isKicker = section.configString.indexOf('kicker') > -1;
   const shouldSupplant = section.configString.indexOf('supplant') > -1;
   const shouldVideoPlayOnce = section.configString.indexOf('once') > -1;
-
+  /** @type {(string|undefined)[]} */
+  const [, , mediaWidthValue, mediaWidthUnit] = section.configString.match(/mediawidth(([0-9]+)(px|pct|rem))/) || [];
   let candidateNodes = section.betweenNodes;
 
   if (!isNoMedia && meta.relatedMedia != null) {
@@ -308,6 +314,9 @@ export const transformSection = (section, meta) => {
       isFloating,
       isLayered,
       isKicker,
+      mediaWidth: mediaWidthValue
+        ? { value: +mediaWidthValue, units: mediaWidthUnit?.replace('pct', '%') || 'px' }
+        : undefined,
       miscContentEls: [],
       shouldVideoPlayOnce
     }

--- a/src/app/components/Header/index.lazy.scss
+++ b/src/app/components/Header/index.lazy.scss
@@ -55,6 +55,8 @@ $abreastChildSpacing: $unit * 2.5;
   }
 
   &:has(.is-original) {
+    width: var(--od-header-media-width);
+    margin: auto;
     :not(.is-layered) > & {
       max-height: none;
     }

--- a/src/app/components/Header/index.lazy.scss
+++ b/src/app/components/Header/index.lazy.scss
@@ -54,6 +54,17 @@ $abreastChildSpacing: $unit * 2.5;
     background-color: $color-lightBg;
   }
 
+  &:has(.is-original) {
+    :not(.is-layered) > & {
+      max-height: none;
+    }
+  }
+
+  .is-original {
+    max-height: calc(100vh - var(--Main-offsetTop) - var(--Header-contentPeek));
+  }
+
+  &:has(.is-original),
   .is-abreast > & {
     background-color: transparent;
   }

--- a/src/app/components/Picture/index.lazy.scss
+++ b/src/app/components/Picture/index.lazy.scss
@@ -32,6 +32,13 @@
     will-change: opacity;
   }
 
+  &.is-original {
+    max-height: 100%;
+    img {
+      object-fit: contain;
+    }
+  }
+
   @media #{$mq-lt-lg} {
     &.is-contained img {
       object-fit: contain;

--- a/src/app/components/Sizer/index.js
+++ b/src/app/components/Sizer/index.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { enqueue, subscribe } from '../../scheduler';
 import styles from './index.lazy.scss';
 
@@ -10,9 +11,14 @@ const DEFAULT_SIZE_RATIOS = {
 };
 export const SIZES = Object.keys(DEFAULT_SIZE_RATIOS);
 
+/** @type {HTMLDivElement[]} */
 const instances = [];
+/** @type {number} */
 let lastKnownNumInstances;
 
+/**
+ * @param {Record<string, string>} sizeRatios
+ */
 const Sizer = sizeRatios => {
   const el = document.createElement('div');
 


### PR DESCRIPTION
Also adds a bunch more type definitions.

@AshKyd — I'd be interested to know how this compares to the image part of https://github.com/abcnews/interactive-hero-images 

I think it makes reasonable assumptions about what to do at different viewport sizes, but there is definitely some compromise.