### PR TITLE
Support 'use original image' in article content

### DIFF
--- a/src/app/components/ImageEmbed/index.js
+++ b/src/app/components/ImageEmbed/index.js
@@ -45,13 +45,26 @@ export const transformElement = el => {
 
   const imageDoc = imgEl ? lookupImageByAssetURL(imgEl.src) : getMeta().mediaById?.[imgId || ''];
 
-  if (!imageDoc?.media || imageDoc.media.image.primary.complete.length < 2) {
-    // Custom Images appear to be Images in Terminus V2. We should ignore them (for now).
-    // TODO: A custom image embed solution. Captionless with custom aspect ratio? #config for max-width?
+  if (!imageDoc?.media) {
+    return;
+  }
+
+  const isOriginal = imageDoc.media.image.primary.complete.length < 2;
+
+  // For backward compatibility reasons, we should not transform embedded images with 'use original image' checked in
+  // the CMS. However, these images can be transformed into Odyssey image embeds by embedding them with a `#image<id>`
+  // tag. It might be possible to re-visit this if we require a specific config to enable conversion which would exclude
+  // previously published stories from conversion.
+  if (isOriginal && imgEl) {
     return;
   }
 
   const configString = grabPrecedingConfigString(el);
+
+  // TODO: Support defining the size and positioning for 'use original' images.
+  // /** @type {(string|undefined)[]} */
+  // const [, , imageWidthValue, imageWidthUnit] = configString.match(/width(([0-9]+)(px|pct|rem))/) || [];
+
   const descriptorAlignment = el._descriptor ? EMBED_ALIGNMENT_MAP[el._descriptor.props.align] : undefined;
   const [, alignment] = configString.match(ALIGNMENT_PATTERN) || [, descriptorAlignment];
   const ratios = getRatios(configString);
@@ -59,19 +72,21 @@ export const transformElement = el => {
   const unlink = configString.indexOf('unlink') > -1;
   const alt = imageDoc.alt;
 
+  const pictureEl = Picture({
+    src: isOriginal ? imageDoc.media.image.primary.complete[0].url : imageDoc.media.image.primary.images['3x2'],
+    alt,
+    ratios: {
+      sm: ratios.sm || '3x4',
+      md: ratios.md || '4x3',
+      lg: ratios.lg,
+      xl: ratios.xl
+    },
+    linkUrl: `/news/${imageDoc.id}`,
+    shouldLazyLoad: !isStatic
+  });
+
   const imageEmbedEl = ImageEmbed({
-    pictureEl: Picture({
-      src: imageDoc.media.image.primary.images['3x2'],
-      alt,
-      ratios: {
-        sm: ratios.sm || '3x4',
-        md: ratios.md || '4x3',
-        lg: ratios.lg,
-        xl: ratios.xl
-      },
-      linkUrl: `/news/${imageDoc.id}`,
-      shouldLazyLoad: !isStatic
-    }),
+    pictureEl,
     captionEl: createCaptionFromTerminusDoc(imageDoc, unlink),
     alignment,
     isFull: configString.indexOf('full') > -1,

--- a/src/app/components/ImageEmbed/index.js
+++ b/src/app/components/ImageEmbed/index.js
@@ -31,6 +31,9 @@ const ImageEmbed = ({ pictureEl, captionEl, alignment, isFull, isCover, isAnon }
 
 export default ImageEmbed;
 
+/**
+ * @param {HTMLElement & {_descriptor?: {props: {align: 'floatLeft' | 'floatRight'}}}} el The element to transform into an image embed
+ */
 export const transformElement = el => {
   const mountValue = isMount(el) ? getMountValue(el) : '';
   const imgEl = getChildImage(el);

--- a/src/app/components/Picture/index.js
+++ b/src/app/components/Picture/index.js
@@ -22,7 +22,7 @@ const WIDTHS = [700, 940, 1400, 2150];
  * @param {object} obj
  * @param {string} [obj.src]
  * @param {string|null} [obj.alt]
- * @param {Record<string, string>} [obj.ratios]
+ * @param {Record<string, string | undefined>} [obj.ratios]
  * @param {string} [obj.linkUrl]
  * @param {boolean} [obj.isContained]
  * @param {boolean} [obj.shouldLazyLoad]
@@ -31,16 +31,17 @@ const WIDTHS = [700, 940, 1400, 2150];
 const Picture = ({
   src = SMALLEST_IMAGE,
   alt = '',
-  ratios = {},
+  ratios: requestedRatios = {},
   linkUrl = '',
   isContained = false,
   shouldLazyLoad = true
 }) => {
-  ratios = {
-    sm: ratios.sm || DEFAULT_RATIOS.sm,
-    md: ratios.md || DEFAULT_RATIOS.md,
-    lg: ratios.lg || DEFAULT_RATIOS.lg,
-    xl: ratios.xl || DEFAULT_RATIOS.xl
+  /** @type {Record<string, string>} */
+  const ratios = {
+    sm: requestedRatios.sm || DEFAULT_RATIOS.sm,
+    md: requestedRatios.md || DEFAULT_RATIOS.md,
+    lg: requestedRatios.lg || DEFAULT_RATIOS.lg,
+    xl: requestedRatios.xl || DEFAULT_RATIOS.xl
   };
 
   /**


### PR DESCRIPTION
This add support for embedding images with the 'use original image' flag set in the CMS using the 
standard Odyssey ImageEmbed component. For backward compatibility reasons this only takes effect if the
image is embedded using `#image<id>` in the text and adding the image as related media.

- **Better types**
- **Support embedding original images by marker/tag**
