### PR TITLE
bug: EmphasisedText soft attributions go missing

### DIFF
--- a/src/app/components/Quote/index.js
+++ b/src/app/components/Quote/index.js
@@ -30,11 +30,7 @@ const Quote = ({ isPullquote = false, alignment, parEls = [], attributionNodes =
 
   styles.use();
 
-  return html`
-    <div class="${className}">
-      <blockquote>${parEls.concat(attributionEl)}</blockquote>
-    </div>
-  `;
+  return html` <div class="${className}">${parEls.concat(attributionEl)}</div> `;
 };
 
 export default Quote;
@@ -52,7 +48,12 @@ export const createFromElement = (el, options) => {
   const config = {
     isPullquote: componentName === 'Pullquote' || componentName === 'EmphasisedText',
     alignment,
-    parEls: $$('p,blockquote', clone),
+
+    // The News Web EmphasisedText component returns contents as either
+    // paragraph(s), or a combo of blockquote+span depending on the text.
+    parEls: $$('p,blockquote,span', clone),
+
+    // These can no longer be created in Core, but still exist in legacy articles.
     attributionNodes: ($('cite', clone) || MOCK_NODE).childNodes
   };
 


### PR DESCRIPTION
We had an issue come in about text in Emphasised Text blocks disappearing. Turns out there was a change to how Emphasised Text blocks work in News Web abut 9 months ago.

The change turns quotes into HTML `<blockquote>`s, and text followed by a phrase including one of these words gets turned into a citation: `said|stated|noted|reported|explained|added|mentioned|told|replied`.

So **"this is a quote" he said** gets split into two parts, "this is a quote" and "he said". Which is why in Odyssey the second attribution part is going missing.

1. The simple fix is to pass both of these elements through, which seems to work just fine.
2. I've also left a note that our old handling of `<cite>` elements is a legacy feature, as AFAIK we can no longer create these in the CMS.
3. Given we're passing through `<blockquotes>` as children, I've removed the parent `<blockquote>` from our implementation, so our implementation is the same as the News Web one.
4. I've queried the accessibility of these blockquotes with pseudo-cites because I'm not 100% sure they're right, but this isn't an Odyssey fix so I've left it for now:
<img width="827" height="725" alt="image" src="https://github.com/user-attachments/assets/a5da8b21-7faa-4c37-bdf0-1e2c21505543" />
