### PR TITLE
Don't remove first child of list items

### DIFF
--- a/src/app/reset/index.js
+++ b/src/app/reset/index.js
@@ -11,8 +11,6 @@ const TEMPLATE_REMOVABLES = {
     '[data-component="AppDetailLayout"]',
     '[data-component="DetailLayout"]',
     '[data-component="WebContentWarning"]',
-    'ol>li>span:first-child',
-    'ul>li>span:first-child',
     '[data-component="NewsTicker"]',
     '[data-component="StickyHeader"]',
     ':not(aside)>[data-component="Sidebar"]'


### PR DESCRIPTION
This fixes #86. These elements were originally removed because the way PL implemented bullets and numbering was undesirable in Odyssey, but this has changed.
