### PR TITLE
Transfer data-scheme attributes to color-scheme css props

### DIFF
--- a/src/app/colours.scss
+++ b/src/app/colours.scss
@@ -7,6 +7,9 @@
 // or go away.
 
 [data-scheme='light'] {
+
+  color-scheme: light;
+
   // Surfaces
   --od-colour-surface-neutral: var(--nw-colour-surface-neutral, rgb(255, 255, 255));
   --od-colour-surface-utility: #75808a26;
@@ -51,6 +54,9 @@
 }
 
 [data-scheme='dark'] {
+
+  color-scheme: dark;
+
   // Surfaces
   --od-colour-surface-neutral: var(--nw-colour-surface-neutral, rgb(15, 15, 15));
   --od-colour-surface-utility: #30323699;

--- a/src/app/constants.js
+++ b/src/app/constants.js
@@ -140,7 +140,7 @@ export const EMBED_ALIGNMENT_MAP = {
  * a dark variant of this theme. The light/dark is controlled by a 'scheme' variable in PL.
  *
  * TODO: This is hard coded in Odyssey for now, but we may want to adopt the PL themes which can
- * be found on the `data-scheme` attribute on `<body>`
+ * be found on the `data-theme` attribute on `<body>`
  */
 export const THEME = 'light-blue';
 


### PR DESCRIPTION
We've supported Presentation Layer's custom colour scheme attributes in Odyssey for some time, but these should also be expressed as CSS color-scheme properties to ensure descendent elements understand their environment.

This will let us, for example, rely on web-standard colour scheme support mechanics for iframe embeds which have colour scheme support defined.
