### PR TITLE
New header type: art directed image replacement

### DIFF
--- a/src/app/components/Header/index.js
+++ b/src/app/components/Header/index.js
@@ -28,6 +28,7 @@ import styles from './index.lazy.scss';
  * @prop {Element[]} miscContentEls
  * @prop {import('../../utils/misc').Ratios} ratios
  * @prop {boolean} shouldVideoPlayOnce
+ * @prop {boolean} shouldReplace
  * @prop {string|number} videoId
  */
 
@@ -51,6 +52,7 @@ const Header = ({
   miscContentEls = [],
   ratios = {},
   shouldVideoPlayOnce,
+  shouldReplace,
   videoId
 }) => {
   isFloating = isFloating || (isLayered && !imgEl && !videoId);
@@ -109,7 +111,9 @@ const Header = ({
 
   const titleEl = html`
     <h1>
-      ${isKicker && meta.title && meta.title.indexOf(': ') > -1
+      ${shouldReplace
+        ? mediaEl
+        : isKicker && meta.title && meta.title.indexOf(': ') > -1
         ? meta.title.split(': ').map((text, index) => (index === 0 ? html`<small>${text}</small>` : text))
         : meta.title}
     </h1>
@@ -154,7 +158,7 @@ const Header = ({
 
   const headerEl = html`
     <div class="${className}" data-scheme="${scheme}" data-theme="${THEME}">
-      ${mediaEl
+      ${mediaEl && !shouldReplace
         ? html`
             <div
               class="${mediaClassName}"
@@ -246,6 +250,7 @@ export const transformSection = (section, meta) => {
   const isNoMedia = isFloating || section.configString.indexOf('nomedia') > -1;
   const isKicker = section.configString.indexOf('kicker') > -1;
   const shouldSupplant = section.configString.indexOf('supplant') > -1;
+  const shouldReplace = section.configString.indexOf('replace') > -1;
   const shouldVideoPlayOnce = section.configString.indexOf('once') > -1;
   /** @type {(string|undefined)[]} */
   const [, , mediaWidthValue, mediaWidthUnit] = section.configString.match(/mediawidth(([0-9]+)(px|pct|rem))/) || [];
@@ -305,7 +310,8 @@ export const transformSection = (section, meta) => {
         ? { value: +mediaWidthValue, units: mediaWidthUnit?.replace('pct', '%') || 'px' }
         : undefined,
       miscContentEls: [],
-      shouldVideoPlayOnce
+      shouldVideoPlayOnce,
+      shouldReplace
     }
   );
 

--- a/src/app/components/Header/index.js
+++ b/src/app/components/Header/index.js
@@ -23,6 +23,7 @@ import styles from './index.lazy.scss';
  * @prop {boolean} isPale
  * @prop {boolean} isVideoYouTube
  * @prop {boolean} isParallax
+ * @prop {boolean} isArtDirected
  * @prop {Partial<import('src/app/meta').MetaData>} meta
  * @prop {{value: number; units: string}} [mediaWidth]
  * @prop {Element[]} miscContentEls
@@ -53,7 +54,8 @@ const Header = ({
   ratios = {},
   shouldVideoPlayOnce,
   shouldReplace,
-  videoId
+  videoId,
+  isArtDirected
 }) => {
   isFloating = isFloating || (isLayered && !imgEl && !videoId);
   isLayered = isLayered || isFloating;
@@ -91,7 +93,8 @@ const Header = ({
       src: imgEl.src,
       alt: imgEl.getAttribute('alt'),
       ratios,
-      shouldLazyLoad: false
+      shouldLazyLoad: false,
+      isArtDirected
     });
   } else if (videoId) {
     mediaEl = isVideoYouTube
@@ -226,13 +229,15 @@ function fetchInfoSourceLogo(meta, el, variant) {
 
     if (logoDocRef) {
       fetchDocument({ id: logoDocRef.id, type: logoDocRef.docType.toLowerCase() }).then(imageDoc => {
-        const image = imageDoc.media.image.primary.complete[0];
-        const imageRatio = image.height / image.width;
+        if ('media' in imageDoc) {
+          const image = imageDoc.media.image.primary.complete[0];
+          const imageRatio = image.height / image.width;
 
-        el.className = `${el.className} has-logo`;
-        // Height based on the image ratio (wider is shorter), clamped between 48px and 64px
-        el.style.height = `${clampNumber(Math.round(64 * imageRatio), 48, 64)}px`;
-        el.style.backgroundImage = `url(${image.url})`;
+          el.className = `${el.className} has-logo`;
+          // Height based on the image ratio (wider is shorter), clamped between 48px and 64px
+          el.style.height = `${clampNumber(Math.round(64 * imageRatio), 48, 64)}px`;
+          el.style.backgroundImage = `url(${image.url})`;
+        }
       });
     }
   });
@@ -249,6 +254,7 @@ export const transformSection = (section, meta) => {
   const isAbreast = section.configString.indexOf('abreast') > -1;
   const isNoMedia = isFloating || section.configString.indexOf('nomedia') > -1;
   const isKicker = section.configString.indexOf('kicker') > -1;
+  const isArtDirected = section.configString.indexOf('artdirected') > -1;
   const shouldSupplant = section.configString.indexOf('supplant') > -1;
   const shouldReplace = section.configString.indexOf('replace') > -1;
   const shouldVideoPlayOnce = section.configString.indexOf('once') > -1;
@@ -306,6 +312,7 @@ export const transformSection = (section, meta) => {
       isParallax,
       isLayered,
       isKicker,
+      isArtDirected,
       mediaWidth: mediaWidthValue
         ? { value: +mediaWidthValue, units: mediaWidthUnit?.replace('pct', '%') || 'px' }
         : undefined,

--- a/src/app/components/Picture/directed.js
+++ b/src/app/components/Picture/directed.js
@@ -1,0 +1,48 @@
+// @ts-check
+import { getImages } from '@abcnews/terminus-fetch';
+import { fetchDocument } from '../../utils/content';
+import { srcsetFromRenditions } from '.';
+import { prepend } from '../../utils/dom';
+import { BP, MQ, UNIT } from '../../constants';
+import html from 'nanohtml';
+
+/**
+ *
+ * @param {object} options
+ * @param {MediaEmbedded} options.primaryImage
+ * @param {HTMLPictureElement} options.pictureEl
+ * @param {HTMLElement} options.rootEl
+ */
+export const initArtDirection = async ({ primaryImage, pictureEl, rootEl }) => {
+  const doc = await fetchDocument(primaryImage.id);
+  const alts = await Promise.all(
+    (doc.contextSettings['meta.data.name'].alts || []).map(async d => {
+      return { width: d.width, image: await fetchDocument(d.image.id) };
+    })
+  );
+  const srcsets = alts.map(({ width, image }) => {
+    const renditions = getImages(image).renditions;
+    return { width, srcset: srcsetFromRenditions(renditions) };
+  });
+
+  srcsets.forEach(({ width, srcset }) => {
+    const mq = MQ[width.toUpperCase()];
+    if (mq) {
+      const source = html`<source
+        media="${mq}"
+        srcset="${srcset}"
+        sizes="${MQ.GT_MD} ${Math.round(BP.LG * 0.666)}px, 100vw"
+      />`;
+      prepend(pictureEl, source);
+    }
+  });
+
+  const reveal = () => rootEl.classList.remove('awaiting-alternatives');
+
+  const img = pictureEl.getElementsByTagName('img')[0];
+  if (img) {
+    img.addEventListener('load', reveal);
+  }
+
+  setTimeout(reveal, 500);
+};

--- a/src/app/components/Picture/directed.js
+++ b/src/app/components/Picture/directed.js
@@ -16,7 +16,7 @@ import html from 'nanohtml';
 export const initArtDirection = async ({ primaryImage, pictureEl, rootEl }) => {
   const doc = await fetchDocument(primaryImage.id);
   const alts = await Promise.all(
-    (doc.contextSettings['meta.data.name'].alts || []).map(async d => {
+    (doc.contextSettings['odyssey'].alts || []).map(async d => {
       return { width: d.width, image: await fetchDocument(d.image.id) };
     })
   );

--- a/src/app/components/Picture/index.js
+++ b/src/app/components/Picture/index.js
@@ -8,6 +8,7 @@ import { append } from '../../utils/dom';
 import Sizer from '../Sizer';
 import styles from './index.lazy.scss';
 import { addLazyLoadableAPI } from './lazy';
+import { initArtDirection } from './directed';
 
 const DEFAULT_RATIOS = {
   sm: '1x1',
@@ -25,6 +26,7 @@ const WIDTHS = [700, 940, 1400, 2150];
  * @param {Record<string, string | undefined>} [obj.ratios]
  * @param {string} [obj.linkUrl]
  * @param {boolean} [obj.isContained]
+ * @param {boolean} [obj.isArtDirected]
  * @param {boolean} [obj.shouldLazyLoad]
  * @returns {HTMLElement}
  */
@@ -34,8 +36,13 @@ const Picture = ({
   ratios: requestedRatios = {},
   linkUrl = '',
   isContained = false,
+  isArtDirected = false,
   shouldLazyLoad = true
 }) => {
+  if (isArtDirected) {
+    shouldLazyLoad = false;
+  }
+
   /** @type {Record<string, string>} */
   const ratios = {
     sm: requestedRatios.sm || DEFAULT_RATIOS.sm,
@@ -95,7 +102,13 @@ const Picture = ({
   /**
    * @type {HTMLElement & {api?: import('./lazy').LazyLoadAPI}}
    */
-  const rootEl = html`<a class=${cn('Picture', { 'is-contained': isContained, 'is-original': isOriginal })}
+  const rootEl = html`<a
+    class=${cn('Picture', {
+      'is-contained': isContained,
+      'is-original': isOriginal,
+      'is-art-directed': isArtDirected,
+      'awaiting-alternatives': isArtDirected
+    })}
     >${sizerEl}${pictureEl}</a
   >`;
 
@@ -116,6 +129,12 @@ const Picture = ({
     rootEl.setAttribute('loaded', '');
   }
 
+  // Unfortunately, we can't initialise the art-direction here because it needs to fetch more data from Terminus, so
+  // it's an async operation and everything else here is synchronous.
+  if (isArtDirected && imageDoc) {
+    initArtDirection({ primaryImage: imageDoc, pictureEl, rootEl });
+  }
+
   styles.use();
 
   return rootEl;
@@ -129,7 +148,7 @@ export default Picture;
  * @param {string} [preferredRatio]
  * @returns
  */
-function srcsetFromRenditions(renditions, preferredRatio) {
+export function srcsetFromRenditions(renditions, preferredRatio) {
   if (!renditions) {
     return null;
   }

--- a/src/app/components/Picture/index.lazy.scss
+++ b/src/app/components/Picture/index.lazy.scss
@@ -39,6 +39,19 @@
     }
   }
 
+  &.is-art-directed {
+    &.awaiting-alternatives {
+      opacity: 0;
+    }
+
+    .Sizer {
+      display: none;
+    }
+    img {
+      position: relative;
+    }
+  }
+
   @media #{$mq-lt-lg} {
     &.is-contained img {
       object-fit: contain;

--- a/src/app/meta/index.js
+++ b/src/app/meta/index.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { parse } from '@abcnews/alternating-case-to-object';
-import { getTier, TIERS, getApplication, APPLICATIONS } from '@abcnews/env-utils';
+import { getTier, TIERS } from '@abcnews/env-utils';
 import { url2cmid } from '@abcnews/url2cmid';
 import { INFO_SOURCE_LOGOS_HTML_FRAGMENT_ID, SELECTORS, VIEWPORT_HEIGHT_THRESHOLD } from '../constants';
 import { fetchDocument } from '../utils/content';

--- a/src/app/utils/content.js
+++ b/src/app/utils/content.js
@@ -1,13 +1,12 @@
 // @ts-check
 import { fetchOne } from '@abcnews/terminus-fetch';
 
-/** @type {Record<string, Promise<TerminusArticle>>} */
+/** @type {Record<string, Promise<TerminusArticle | TerminusImage>>} */
 const cache = {};
 
 /**
  *
  * @param {{id:string; type: string}|string} optionsOrId
- * @returns {Promise<object>}
  */
 export const fetchDocument = optionsOrId => {
   const options = typeof optionsOrId === 'object' ? optionsOrId : { id: optionsOrId };
@@ -24,7 +23,6 @@ export const fetchDocument = optionsOrId => {
  *
  * @param {{id: string, type:string} | string} optionsOrId
  * @param {Partial<import('../meta').MetaData>} meta
- * @returns
  */
 export const getOrFetchDocument = (optionsOrId, meta) => {
   const { id } = typeof optionsOrId === 'object' ? optionsOrId : { id: optionsOrId };

--- a/types.d.ts
+++ b/types.d.ts
@@ -10,9 +10,36 @@ interface Window {
   dataLayer?: any;
 }
 
+interface TerminusImageEmbedded {
+  primaryContext: PrimaryContext;
+}
+
+interface TerminusImage {
+  _embedded: TerminusImageEmbedded;
+  _links: TerminusLinks;
+  alt: string;
+  canonicalURI: string;
+  canonicalURL: string;
+  contentSource: 'coremedia';
+  contextSettings: ContextSettings;
+  dates: Dates;
+  docType: string;
+  genre: string;
+  id: string;
+  isOriginalEnforced: boolean;
+  lang: string;
+  media: Media;
+  notChildFriendly: boolean;
+  rightsHolder: string[];
+  site: Site;
+  title: string;
+  titleAlt: TitleAlt;
+  version: number;
+}
+
 interface TerminusArticle {
   _embedded: TerminusArticleEmbedded;
-  _links: TerminusArticleLinks;
+  _links: TerminusLinks;
   canonicalURI: string;
   canonicalURL: string;
   contentSource: string;
@@ -33,9 +60,9 @@ interface TerminusArticle {
   sourceURL: string;
   synopsis: string;
   synopsisAlt: SynopsisAlt;
-  text: Text;
+  text: string;
   title: string;
-  titleAlt: MediaEmbeddedTitleAlt;
+  titleAlt: TitleAlt;
   version: number;
 }
 
@@ -117,7 +144,7 @@ interface MediaEmbedded {
   lang: string;
   media?: Media;
   title?: string;
-  titleAlt?: MediaEmbeddedTitleAlt;
+  titleAlt?: TitleAlt;
   _embedded?: MediaEmbeddedEmbedded;
   synopsis?: string;
   synopsisAlt?: SynopsisAlt;
@@ -321,7 +348,7 @@ interface FluffyParameters {
   show: string;
 }
 
-interface MediaEmbeddedTitleAlt {
+interface TitleAlt {
   lg: string;
   md: string;
   sm: string;
@@ -353,7 +380,7 @@ interface Subject {
   title: string;
 }
 
-interface TerminusArticleLinks {
+interface TerminusLinks {
   self: Self;
   'terminus:teasable': Self;
 }
@@ -367,8 +394,14 @@ interface ContextSettings {
 }
 
 interface MetaDataName {
-  'replacement-title': string;
-  theme: string;
+  'replacement-title'?: string;
+  theme?: string;
+  alts?: {
+    width: string;
+    image: {
+      id: string;
+    };
+  }[];
 }
 
 interface EmbeddedMedia {


### PR DESCRIPTION
This PR supports a new type of header that replaces the title text with an art-directed responsive image. 

This is an experimental feature which, in part, is intended as a proof of concept for a future CMS supported art-directed responsive image technique. It uses a new technique where alternative images are defined in Core Media on the image document.

The art-directed responsive image implementation has the potential to be expanded for use in the body text. 

The main image is the 'mobile' image and alternative images for larger screens are defined in the Local Settings field of the image document. The `image` key is a link to the alternative image document to use. The `width` key must be one of Odyssey's supported breakpoints.

<img width="518" height="192" alt="image" src="https://github.com/user-attachments/assets/9f273c72-553c-4962-a74f-e696bb3bfaf3" />

Commits:
- **feat: Add option to replace article title with header image**
- **feat: support art-directed imagery in the header**
