### PR TITLE
feat: override block transitions to use crossfades when reduced motion enabled

### DIFF
--- a/src/app/components/Block/media.scss
+++ b/src/app/components/Block/media.scss
@@ -308,6 +308,30 @@
   }
 }
 
+body.is-reduced-motion {
+  .background-transition {
+    &.bouncefade,
+    &.zoomfade,
+    &.slideup,
+    &.slidedown,
+    &.slideright,
+    &.slideleft,
+    &.shuffle {
+      &.transition-in {
+        opacity: 0;
+        z-index: 1;
+        animation: fadeIn 1s ease 0s 1 normal forwards !important;
+      }
+
+      &.transition-out {
+        opacity: 1;
+        z-index: 0;
+        animation: none !important;
+      }
+    }
+  }
+}
+
 .Block-mediaCaption {
   transition: opacity 0.5s;
   opacity: 0;


### PR DESCRIPTION
This overrides the default block transitions to replace any zooms or pans with straight crossfades.

This only works when the reduced motion plugin is present, but now I think of it we could also do it across the board if the system setting is set.